### PR TITLE
[1차 과제 - Step2] 이상진

### DIFF
--- a/src/main/java/kuit/subway/BaseTimeEntity.java
+++ b/src/main/java/kuit/subway/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package kuit.subway;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    protected LocalDateTime createdDate;
+
+    @LastModifiedDate
+    protected LocalDateTime modifiedDate;
+}

--- a/src/main/java/kuit/subway/global/config/JpaConfig.java
+++ b/src/main/java/kuit/subway/global/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package kuit.subway.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/kuit/subway/global/exception/CustomExceptionStatus.java
+++ b/src/main/java/kuit/subway/global/exception/CustomExceptionStatus.java
@@ -17,6 +17,9 @@ public enum CustomExceptionStatus implements ExceptionStatus {
     // station exception
     DUPLICATED_STATION(HttpStatus.BAD_REQUEST, "중복된 이름의 역이 존재합니다."),
     NOT_EXISTED_STATION(HttpStatus.BAD_REQUEST, "존재하지 않는 역입니다."),
+
+    // line exception
+    NOT_EXISTED_LINE(HttpStatus.BAD_REQUEST, "존재하지 않는 노선입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kuit/subway/global/exception/CustomExceptionStatus.java
+++ b/src/main/java/kuit/subway/global/exception/CustomExceptionStatus.java
@@ -20,6 +20,7 @@ public enum CustomExceptionStatus implements ExceptionStatus {
 
     // line exception
     NOT_EXISTED_LINE(HttpStatus.BAD_REQUEST, "존재하지 않는 노선입니다."),
+    DUPLICATED_UP_STATION_AND_DOWN_STATION(HttpStatus.BAD_REQUEST, "상행종점역과 하행종점역이 중복됩니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kuit/subway/line/controller/LineController.java
+++ b/src/main/java/kuit/subway/line/controller/LineController.java
@@ -7,7 +7,6 @@ import kuit.subway.line.dto.response.LineResponse;
 import kuit.subway.line.service.LineService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +15,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
 
 @RestController
 @RequestMapping("/lines")
@@ -28,15 +29,14 @@ public class LineController {
     @PostMapping
     public ResponseEntity<LineCreateResponse> createLine(@Valid @RequestBody LineRequest request) {
         LineCreateResponse response = lineService.createLine(request);
-        return ResponseEntity.status(HttpStatus.CREATED)
+        return ResponseEntity.created(URI.create("/stations/" + response.getId()))
                 .body(response);
     }
 
     @GetMapping("/{lineId}")
     public ResponseEntity<LineResponse> showLine(@PathVariable Long lineId) {
         LineResponse response = lineService.showLine(lineId);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(response);
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/{lineId}")
@@ -49,6 +49,6 @@ public class LineController {
     @DeleteMapping("/{lineId}")
     public ResponseEntity<Void> deleteLine(@PathVariable Long lineId) {
         lineService.deleteLine(lineId);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/kuit/subway/line/controller/LineController.java
+++ b/src/main/java/kuit/subway/line/controller/LineController.java
@@ -1,7 +1,7 @@
 package kuit.subway.line.controller;
 
 import jakarta.validation.Valid;
-import kuit.subway.line.dto.request.LineCreateRequest;
+import kuit.subway.line.dto.request.LineRequest;
 import kuit.subway.line.dto.response.LineCreateResponse;
 import kuit.subway.line.dto.response.LineResponse;
 import kuit.subway.line.service.LineService;
@@ -23,7 +23,7 @@ public class LineController {
     private final LineService lineService;
 
     @PostMapping("/lines")
-    public ResponseEntity<LineCreateResponse> createLine(@Valid @RequestBody LineCreateRequest request) {
+    public ResponseEntity<LineCreateResponse> createLine(@Valid @RequestBody LineRequest request) {
         LineCreateResponse response = lineService.createLine(request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(response);

--- a/src/main/java/kuit/subway/line/controller/LineController.java
+++ b/src/main/java/kuit/subway/line/controller/LineController.java
@@ -35,4 +35,11 @@ public class LineController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(response);
     }
+
+    @PostMapping("/lines/{lineId}")
+    public ResponseEntity<LineResponse> updateLine(@PathVariable Long lineId,
+                                                   @Valid @RequestBody LineRequest request) {
+        LineResponse response = lineService.updateLine(lineId, request);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/kuit/subway/line/controller/LineController.java
+++ b/src/main/java/kuit/subway/line/controller/LineController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -41,5 +42,11 @@ public class LineController {
                                                    @Valid @RequestBody LineRequest request) {
         LineResponse response = lineService.updateLine(lineId, request);
         return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/lines/{lineId}")
+    public ResponseEntity<Void> deleteLine(@PathVariable Long lineId) {
+        lineService.deleteLine(lineId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/kuit/subway/line/controller/LineController.java
+++ b/src/main/java/kuit/subway/line/controller/LineController.java
@@ -1,0 +1,28 @@
+package kuit.subway.line.controller;
+
+import jakarta.validation.Valid;
+import kuit.subway.line.dto.request.LineCreateRequest;
+import kuit.subway.line.dto.response.LineCreateResponse;
+import kuit.subway.line.service.LineService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class LineController {
+
+    private final LineService lineService;
+
+    @PostMapping("/lines")
+    public ResponseEntity<LineCreateResponse> createLine(@Valid @RequestBody LineCreateRequest request) {
+        LineCreateResponse response = lineService.createLine(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(response);
+    }
+}

--- a/src/main/java/kuit/subway/line/controller/LineController.java
+++ b/src/main/java/kuit/subway/line/controller/LineController.java
@@ -14,37 +14,39 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/lines")
 @RequiredArgsConstructor
 @Slf4j
 public class LineController {
 
     private final LineService lineService;
 
-    @PostMapping("/lines")
+    @PostMapping
     public ResponseEntity<LineCreateResponse> createLine(@Valid @RequestBody LineRequest request) {
         LineCreateResponse response = lineService.createLine(request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(response);
     }
 
-    @GetMapping("/lines/{lineId}")
+    @GetMapping("/{lineId}")
     public ResponseEntity<LineResponse> showLine(@PathVariable Long lineId) {
         LineResponse response = lineService.showLine(lineId);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(response);
     }
 
-    @PostMapping("/lines/{lineId}")
+    @PostMapping("/{lineId}")
     public ResponseEntity<LineResponse> updateLine(@PathVariable Long lineId,
                                                    @Valid @RequestBody LineRequest request) {
         LineResponse response = lineService.updateLine(lineId, request);
         return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping("/lines/{lineId}")
+    @DeleteMapping("/{lineId}")
     public ResponseEntity<Void> deleteLine(@PathVariable Long lineId) {
         lineService.deleteLine(lineId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();

--- a/src/main/java/kuit/subway/line/controller/LineController.java
+++ b/src/main/java/kuit/subway/line/controller/LineController.java
@@ -3,11 +3,14 @@ package kuit.subway.line.controller;
 import jakarta.validation.Valid;
 import kuit.subway.line.dto.request.LineCreateRequest;
 import kuit.subway.line.dto.response.LineCreateResponse;
+import kuit.subway.line.dto.response.LineResponse;
 import kuit.subway.line.service.LineService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,6 +25,13 @@ public class LineController {
     @PostMapping("/lines")
     public ResponseEntity<LineCreateResponse> createLine(@Valid @RequestBody LineCreateRequest request) {
         LineCreateResponse response = lineService.createLine(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(response);
+    }
+
+    @GetMapping("/lines/{lineId}")
+    public ResponseEntity<LineResponse> showLine(@PathVariable Long lineId) {
+        LineResponse response = lineService.showLine(lineId);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(response);
     }

--- a/src/main/java/kuit/subway/line/domain/Line.java
+++ b/src/main/java/kuit/subway/line/domain/Line.java
@@ -52,4 +52,15 @@ public class Line extends BaseTimeEntity {
     private void addStations(List<Station> stations) {
         stations.forEach(station -> station.addLine(this));
     }
+
+    public void updateInfo(String name, String color, Long distance) {
+        this.name = name;
+        this.color = color;
+        this.distance = distance;
+    }
+
+    public void updateStations(List<Station> stations) {
+        this.stations = stations;
+        addStations(stations);
+    }
 }

--- a/src/main/java/kuit/subway/line/domain/Line.java
+++ b/src/main/java/kuit/subway/line/domain/Line.java
@@ -1,0 +1,52 @@
+package kuit.subway.line.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import kuit.subway.BaseTimeEntity;
+import kuit.subway.station.domain.Station;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Line extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 10, nullable = false)
+    private String name;
+
+    @Column(length = 10, nullable = false)
+    private String color;
+
+    private Long distance;
+
+    @OneToMany(mappedBy = "line")
+    public List<Station> stations = new ArrayList<>();
+
+    @Builder
+    public Line(String name, String color, Long distance) {
+        this.name = name;
+        this.color = color;
+        this.distance = distance;
+    }
+
+    public void addStations(Station... stations) {
+        Arrays.stream(stations).forEach(station -> station.addLine(this));
+    }
+}

--- a/src/main/java/kuit/subway/line/domain/Line.java
+++ b/src/main/java/kuit/subway/line/domain/Line.java
@@ -61,7 +61,8 @@ public class Line extends BaseTimeEntity {
     }
 
     public void updateStations(List<Station> stations) {
-        this.stations = stations;
+        this.stations.clear();
+        this.stations.addAll(stations);
         addStations(stations);
     }
 }

--- a/src/main/java/kuit/subway/line/domain/Line.java
+++ b/src/main/java/kuit/subway/line/domain/Line.java
@@ -15,7 +15,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 @Entity
@@ -40,13 +39,17 @@ public class Line extends BaseTimeEntity {
     public List<Station> stations = new ArrayList<>();
 
     @Builder
-    public Line(String name, String color, Long distance) {
+    public Line(String name, String color, Long distance, List<Station> stations) {
         this.name = name;
         this.color = color;
         this.distance = distance;
+        if (stations != null) {
+            this.stations = stations;
+            addStations(stations);
+        }
     }
 
-    public void addStations(Station... stations) {
-        Arrays.stream(stations).forEach(station -> station.addLine(this));
+    private void addStations(List<Station> stations) {
+        stations.forEach(station -> station.addLine(this));
     }
 }

--- a/src/main/java/kuit/subway/line/domain/Line.java
+++ b/src/main/java/kuit/subway/line/domain/Line.java
@@ -1,5 +1,6 @@
 package kuit.subway.line.domain;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -35,7 +36,7 @@ public class Line extends BaseTimeEntity {
 
     private Long distance;
 
-    @OneToMany(mappedBy = "line")
+    @OneToMany(mappedBy = "line", cascade = CascadeType.REMOVE, orphanRemoval = true)
     public List<Station> stations = new ArrayList<>();
 
     @Builder

--- a/src/main/java/kuit/subway/line/dto/request/LineCreateRequest.java
+++ b/src/main/java/kuit/subway/line/dto/request/LineCreateRequest.java
@@ -1,0 +1,33 @@
+package kuit.subway.line.dto.request;
+
+import jakarta.validation.constraints.Size;
+import kuit.subway.line.domain.Line;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LineCreateRequest {
+
+    @Size(min = 2, max = 10)
+    private String name;
+    @Size(min = 2, max = 10)
+    private String color;
+    private Long distance;
+
+    private Long downStationId;
+    private Long upStationId;
+
+    public Line toEntity() {
+        return Line.builder()
+                .name(name)
+                .color(color)
+                .distance(distance)
+                .build();
+    }
+}

--- a/src/main/java/kuit/subway/line/dto/request/LineCreateRequest.java
+++ b/src/main/java/kuit/subway/line/dto/request/LineCreateRequest.java
@@ -1,5 +1,7 @@
 package kuit.subway.line.dto.request;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import kuit.subway.line.domain.Line;
 import lombok.AccessLevel;
@@ -18,6 +20,8 @@ public class LineCreateRequest {
     private String name;
     @Size(min = 2, max = 10)
     private String color;
+    @NotNull
+    @Min(1)
     private Long distance;
 
     private Long downStationId;

--- a/src/main/java/kuit/subway/line/dto/request/LineRequest.java
+++ b/src/main/java/kuit/subway/line/dto/request/LineRequest.java
@@ -4,17 +4,20 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import kuit.subway.line.domain.Line;
+import kuit.subway.station.domain.Station;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Builder
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class LineCreateRequest {
+public class LineRequest {
 
     @Size(min = 2, max = 10)
     private String name;
@@ -27,11 +30,12 @@ public class LineCreateRequest {
     private Long downStationId;
     private Long upStationId;
 
-    public Line toEntity() {
+    public Line toEntity(List<Station> stations) {
         return Line.builder()
                 .name(name)
                 .color(color)
                 .distance(distance)
+                .stations(stations)
                 .build();
     }
 }

--- a/src/main/java/kuit/subway/line/dto/response/LineCreateResponse.java
+++ b/src/main/java/kuit/subway/line/dto/response/LineCreateResponse.java
@@ -1,0 +1,18 @@
+package kuit.subway.line.dto.response;
+
+import kuit.subway.line.domain.Line;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class LineCreateResponse {
+
+    private Long id;
+
+    public static LineCreateResponse of(Line line) {
+        return LineCreateResponse.builder()
+                .id(line.getId())
+                .build();
+    }
+}

--- a/src/main/java/kuit/subway/line/dto/response/LineResponse.java
+++ b/src/main/java/kuit/subway/line/dto/response/LineResponse.java
@@ -1,0 +1,32 @@
+package kuit.subway.line.dto.response;
+
+import kuit.subway.line.domain.Line;
+import kuit.subway.station.dto.response.StationResponse;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+@Getter
+public class LineResponse {
+
+    private Long id;
+    private String name;
+    private String color;
+    private List<StationResponse> stations;
+    private LocalDateTime createdDate;
+    private LocalDateTime modifiedDate;
+
+    public static LineResponse of(Line line, List<StationResponse> stations) {
+        return LineResponse.builder()
+                .id(line.getId())
+                .name(line.getName())
+                .color(line.getColor())
+                .stations(stations)
+                .createdDate(line.getCreatedDate())
+                .modifiedDate(line.getModifiedDate())
+                .build();
+    }
+}

--- a/src/main/java/kuit/subway/line/repository/LineRepository.java
+++ b/src/main/java/kuit/subway/line/repository/LineRepository.java
@@ -1,0 +1,7 @@
+package kuit.subway.line.repository;
+
+import kuit.subway.line.domain.Line;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LineRepository extends JpaRepository<Line, Long> {
+}

--- a/src/main/java/kuit/subway/line/service/LineService.java
+++ b/src/main/java/kuit/subway/line/service/LineService.java
@@ -1,0 +1,40 @@
+package kuit.subway.line.service;
+
+import kuit.subway.global.exception.SubwayException;
+import kuit.subway.line.domain.Line;
+import kuit.subway.line.dto.request.LineCreateRequest;
+import kuit.subway.line.dto.response.LineCreateResponse;
+import kuit.subway.line.repository.LineRepository;
+import kuit.subway.station.domain.Station;
+import kuit.subway.station.repository.StationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static kuit.subway.global.exception.CustomExceptionStatus.NOT_EXISTED_STATION;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class LineService {
+
+    private final LineRepository lineRepository;
+    private final StationRepository stationRepository;
+
+    @Transactional
+    public LineCreateResponse createLine(LineCreateRequest request) {
+        Station upStation = stationRepository.findById(request.getUpStationId())
+                .orElseThrow(() -> new SubwayException(NOT_EXISTED_STATION));
+
+        Station downStation = stationRepository.findById(request.getDownStationId())
+                .orElseThrow(() -> new SubwayException(NOT_EXISTED_STATION));
+
+        Line line = request.toEntity();
+        line.addStations(upStation, downStation);
+
+        lineRepository.save(line);
+        return LineCreateResponse.of(line);
+    }
+}

--- a/src/main/java/kuit/subway/line/service/LineService.java
+++ b/src/main/java/kuit/subway/line/service/LineService.java
@@ -4,14 +4,19 @@ import kuit.subway.global.exception.SubwayException;
 import kuit.subway.line.domain.Line;
 import kuit.subway.line.dto.request.LineCreateRequest;
 import kuit.subway.line.dto.response.LineCreateResponse;
+import kuit.subway.line.dto.response.LineResponse;
 import kuit.subway.line.repository.LineRepository;
 import kuit.subway.station.domain.Station;
+import kuit.subway.station.dto.response.StationResponse;
 import kuit.subway.station.repository.StationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
+import static kuit.subway.global.exception.CustomExceptionStatus.NOT_EXISTED_LINE;
 import static kuit.subway.global.exception.CustomExceptionStatus.NOT_EXISTED_STATION;
 
 @Service
@@ -36,5 +41,16 @@ public class LineService {
 
         lineRepository.save(line);
         return LineCreateResponse.of(line);
+    }
+
+    public LineResponse showLine(Long lineId) {
+        Line line = lineRepository.findById(lineId)
+                .orElseThrow(() -> new SubwayException(NOT_EXISTED_LINE));
+
+        List<StationResponse> stations = line.getStations().stream()
+                .map(StationResponse::of)
+                .toList();
+
+        return LineResponse.of(line, stations);
     }
 }

--- a/src/main/java/kuit/subway/line/service/LineService.java
+++ b/src/main/java/kuit/subway/line/service/LineService.java
@@ -51,6 +51,22 @@ public class LineService {
         return LineResponse.of(line, stationResponses);
     }
 
+    @Transactional
+    public LineResponse updateLine(Long lineId, LineRequest request) {
+        Line line = lineRepository.findById(lineId)
+                .orElseThrow(() -> new SubwayException(NOT_EXISTED_LINE));
+
+        validateDuplicatedStations(request);
+        List<Station> stations = extractStationsFrom(request);
+
+        line.updateInfo(request.getName(), request.getColor(), request.getDistance());
+        line.updateStations(stations);
+
+        List<StationResponse> stationResponses = stations.stream().map(StationResponse::of).toList();
+
+        return LineResponse.of(line, stationResponses);
+    }
+
     private void validateDuplicatedStations(LineRequest request) {
         if (request.getUpStationId().equals(request.getDownStationId())) {
             throw new SubwayException(CustomExceptionStatus.DUPLICATED_UP_STATION_AND_DOWN_STATION);

--- a/src/main/java/kuit/subway/line/service/LineService.java
+++ b/src/main/java/kuit/subway/line/service/LineService.java
@@ -1,6 +1,5 @@
 package kuit.subway.line.service;
 
-import kuit.subway.global.exception.CustomExceptionStatus;
 import kuit.subway.global.exception.SubwayException;
 import kuit.subway.line.domain.Line;
 import kuit.subway.line.dto.request.LineRequest;
@@ -17,8 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static kuit.subway.global.exception.CustomExceptionStatus.NOT_EXISTED_LINE;
-import static kuit.subway.global.exception.CustomExceptionStatus.NOT_EXISTED_STATION;
+import static kuit.subway.global.exception.CustomExceptionStatus.*;
 
 @Service
 @Transactional(readOnly = true)
@@ -67,9 +65,17 @@ public class LineService {
         return LineResponse.of(line, stationResponses);
     }
 
+    @Transactional
+    public void deleteLine(Long lineId) {
+        Line line = lineRepository.findById(lineId)
+                .orElseThrow(() -> new SubwayException(NOT_EXISTED_LINE));
+
+        lineRepository.delete(line);
+    }
+
     private void validateDuplicatedStations(LineRequest request) {
         if (request.getUpStationId().equals(request.getDownStationId())) {
-            throw new SubwayException(CustomExceptionStatus.DUPLICATED_UP_STATION_AND_DOWN_STATION);
+            throw new SubwayException(DUPLICATED_UP_STATION_AND_DOWN_STATION);
         }
     }
 

--- a/src/main/java/kuit/subway/station/controller/StationController.java
+++ b/src/main/java/kuit/subway/station/controller/StationController.java
@@ -14,30 +14,32 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
+@RequestMapping("/stations")
 @RequiredArgsConstructor
 @Slf4j
 public class StationController {
 
     private final StationService stationService;
 
-    @PostMapping("/stations")
+    @PostMapping
     public ResponseEntity<StationCreateResponse> createStation(@Valid @RequestBody StationCreateRequest request) {
         StationCreateResponse response = stationService.createStation(request);
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/stations")
+    @GetMapping
     public ResponseEntity<List<StationResponse>> showStations() {
         List<StationResponse> responses = stationService.showStations();
         return ResponseEntity.ok(responses);
     }
 
-    @DeleteMapping("/stations/{stationId}")
+    @DeleteMapping("/{stationId}")
     public ResponseEntity<Void> deleteStation(@PathVariable Long stationId) {
         stationService.deleteStation(stationId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();

--- a/src/main/java/kuit/subway/station/controller/StationController.java
+++ b/src/main/java/kuit/subway/station/controller/StationController.java
@@ -7,7 +7,6 @@ import kuit.subway.station.dto.response.StationResponse;
 import kuit.subway.station.service.StationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -42,6 +41,6 @@ public class StationController {
     @DeleteMapping("/{stationId}")
     public ResponseEntity<Void> deleteStation(@PathVariable Long stationId) {
         stationService.deleteStation(stationId);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/kuit/subway/station/domain/Station.java
+++ b/src/main/java/kuit/subway/station/domain/Station.java
@@ -35,6 +35,5 @@ public class Station {
 
     public void addLine(Line line) {
         this.line = line;
-        line.getStations().add(this);
     }
 }

--- a/src/main/java/kuit/subway/station/domain/Station.java
+++ b/src/main/java/kuit/subway/station/domain/Station.java
@@ -2,9 +2,13 @@ package kuit.subway.station.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import kuit.subway.line.domain.Line;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,4 +29,12 @@ public class Station {
     @Column(length = 20, nullable = false)
     private String name;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "line_id")
+    private Line line;
+
+    public void addLine(Line line) {
+        this.line = line;
+        line.getStations().add(this);
+    }
 }

--- a/src/test/java/kuit/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/kuit/subway/acceptance/LineAcceptanceTest.java
@@ -2,6 +2,7 @@ package kuit.subway.acceptance;
 
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -17,13 +18,15 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class LineAcceptanceTest extends AcceptanceTest {
 
+    @BeforeEach
+    void init() {
+        지하철역_생성(지하철역_생성_요청("강남역"));
+        지하철역_생성(지하철역_생성_요청("성수역"));
+    }
+
     @DisplayName("지하철 노선을 생성한다.")
     @Test
     void createLine(){
-        //given
-        지하철역_생성(지하철역_생성_요청("강남역"));
-        지하철역_생성(지하철역_생성_요청("성수역"));
-
         //when
         ExtractableResponse<Response> response = 노선_생성(노선_요청("경춘선", "grean", 10L, 2L, 1L));
 
@@ -34,10 +37,6 @@ public class LineAcceptanceTest extends AcceptanceTest {
     @DisplayName("검증조건을 만족시키지 않는 노선 생성 요청의 경우, 예외가 발생한다.")
     @Test
     void createLine_Throw_Exception_If_Invalid_Request(){
-        //given
-        지하철역_생성(지하철역_생성_요청("강남역"));
-        지하철역_생성(지하철역_생성_요청("성수역"));
-
         //when
         ExtractableResponse<Response> response =
                 노선_생성(노선_요청("A".repeat(11),"G".repeat(11) , -1L, 2L, 1L));
@@ -49,10 +48,6 @@ public class LineAcceptanceTest extends AcceptanceTest {
     @DisplayName("상행종점역과 하행종점역이 같은 노선 생성 요청의 경우, 예외가 발생한다.")
     @Test
     void createLine_Throw_Exception_If_Duplicated_Stations_Request(){
-        //given
-        지하철역_생성(지하철역_생성_요청("강남역"));
-        지하철역_생성(지하철역_생성_요청("성수역"));
-
         //when
         ExtractableResponse<Response> response =
                 노선_생성(노선_요청("경춘선","grean" , 10L, 1L, 1L));
@@ -65,8 +60,6 @@ public class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void showLines(){
         //given
-        지하철역_생성(지하철역_생성_요청("강남역"));
-        지하철역_생성(지하철역_생성_요청("성수역"));
         노선_생성(노선_요청("경춘선", "green", 10L, 1L, 2L));
 
         //when
@@ -84,8 +77,6 @@ public class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void showLines_Throw_Exception_If_Not_Existed_Line(){
         //given
-        지하철역_생성(지하철역_생성_요청("강남역"));
-        지하철역_생성(지하철역_생성_요청("성수역"));
         노선_생성(노선_요청("경춘선", "green", 10L, 1L, 2L));
 
         //when
@@ -99,8 +90,6 @@ public class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void updateLine(){
         //given
-        지하철역_생성(지하철역_생성_요청("강남역"));
-        지하철역_생성(지하철역_생성_요청("성수역"));
         노선_생성(노선_요청("경춘선", "green", 10L, 1L, 2L));
 
         //when
@@ -114,8 +103,6 @@ public class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void updateLine_Throw_Exception_If_Not_Existed_Line(){
         //given
-        지하철역_생성(지하철역_생성_요청("강남역"));
-        지하철역_생성(지하철역_생성_요청("성수역"));
         노선_생성(노선_요청("경춘선", "green", 10L, 1L, 2L));
 
         //when
@@ -129,8 +116,6 @@ public class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteLine(){
         //given
-        지하철역_생성(지하철역_생성_요청("강남역"));
-        지하철역_생성(지하철역_생성_요청("성수역"));
         노선_생성(노선_요청("경춘선", "green", 10L, 1L, 2L));
 
         //when
@@ -144,8 +129,6 @@ public class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteLine_Throw_Exception_If_Not_Existed_Line(){
         //given
-        지하철역_생성(지하철역_생성_요청("강남역"));
-        지하철역_생성(지하철역_생성_요청("성수역"));
         노선_생성(노선_요청("경춘선", "green", 10L, 1L, 2L));
 
         //when

--- a/src/test/java/kuit/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/kuit/subway/acceptance/LineAcceptanceTest.java
@@ -68,7 +68,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
 
         //then
         assertAll(
-                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(stations).hasSize(2)
         );
     }

--- a/src/test/java/kuit/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/kuit/subway/acceptance/LineAcceptanceTest.java
@@ -32,7 +32,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
     }
 
-    @DisplayName("검증조건을 만족시키지 않는 노선 생성 요청의 경우, 예외를 발생한다.")
+    @DisplayName("검증조건을 만족시키지 않는 노선 생성 요청의 경우, 예외가 발생한다.")
     @Test
     void createLine_Throw_Exception_If_Invalid_Request(){
         //given
@@ -47,7 +47,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 
-    @DisplayName("상행종점역과 하행종점역이 같은 노선 생성 요청의 경우, 예외를 발생한다.")
+    @DisplayName("상행종점역과 하행종점역이 같은 노선 생성 요청의 경우, 예외가 발생한다.")
     @Test
     void createLine_Throw_Exception_If_Duplicated_Stations_Request(){
         //given
@@ -81,7 +81,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
         );
     }
 
-    @DisplayName("존재하지 않는 지하철 노선을 조회시, 예외를 발생한다.")
+    @DisplayName("존재하지 않는 지하철 노선을 조회시, 예외가 발생한다.")
     @Test
     void showLines_Throw_Exception_If_Not_Existed_Line(){
         //given
@@ -111,7 +111,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 
-    @DisplayName("존재하지 않는 지하철 노선을 수정시, 예외를 발생한다.")
+    @DisplayName("존재하지 않는 지하철 노선을 수정시, 예외가 발생한다.")
     @Test
     void updateLine_Throw_Exception_If_Not_Existed_Line(){
         //given
@@ -121,6 +121,36 @@ public class LineAcceptanceTest extends AcceptanceTest {
 
         //when
         ExtractableResponse<Response> response = 노선_변경(2L, 노선_요청("신분당선", "red", 10L, 2L, 1L));
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @DisplayName("지하철 노선을 삭제한다.")
+    @Test
+    void deleteLine(){
+        //given
+        지하철역_생성(지하철역_생성_요청("강남역"));
+        지하철역_생성(지하철역_생성_요청("성수역"));
+        노선_생성(노선_요청("경춘선", "green", 10L, 1L, 2L));
+
+        //when
+        ExtractableResponse<Response> response = 노선_삭제(1L);
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+    @DisplayName("존재하지 않는 지하철 노선을 삭제시, 예외가 발생한다.")
+    @Test
+    void deleteLine_Throw_Exception_If_Not_Existed_Line(){
+        //given
+        지하철역_생성(지하철역_생성_요청("강남역"));
+        지하철역_생성(지하철역_생성_요청("성수역"));
+        노선_생성(노선_요청("경춘선", "green", 10L, 1L, 2L));
+
+        //when
+        ExtractableResponse<Response> response = 노선_삭제(2L);
 
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());

--- a/src/test/java/kuit/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/kuit/subway/acceptance/LineAcceptanceTest.java
@@ -1,0 +1,46 @@
+package kuit.subway.acceptance;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static kuit.subway.acceptance.fixtures.LineAcceptanceFixtures.노선_생성;
+import static kuit.subway.acceptance.fixtures.StationAcceptanceFixtures.지하철역_생성;
+import static kuit.subway.utils.fixtures.LineFixtures.노선_생성_요청;
+import static kuit.subway.utils.fixtures.StationFixtures.지하철역_생성_요청;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LineAcceptanceTest extends AcceptanceTest {
+
+    @DisplayName("지하철 노선을 생성한다.")
+    @Test
+    void createLine(){
+        //given
+        지하철역_생성(지하철역_생성_요청("강남역"));
+        지하철역_생성(지하철역_생성_요청("성수역"));
+
+        //when
+        ExtractableResponse<Response> response =
+                노선_생성(노선_생성_요청("경춘선", "grean", 10L, 2L, 1L));
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+
+    @DisplayName("검증조건을 만족시키지 않는 노선 생성 요청의 경우, 예외를 발생한다.")
+    @Test
+    void createLine_Throw_Exception_If_Invalid_Request(){
+        //given
+        지하철역_생성(지하철역_생성_요청("강남역"));
+        지하철역_생성(지하철역_생성_요청("성수역"));
+
+        //when
+        ExtractableResponse<Response> response =
+                노선_생성(노선_생성_요청("A".repeat(11),"G".repeat(11) , -1L, 2L, 1L));
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+}

--- a/src/test/java/kuit/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/kuit/subway/acceptance/LineAcceptanceTest.java
@@ -11,7 +11,7 @@ import java.util.List;
 import static kuit.subway.acceptance.fixtures.LineAcceptanceFixtures.노선_생성;
 import static kuit.subway.acceptance.fixtures.LineAcceptanceFixtures.노선_조회;
 import static kuit.subway.acceptance.fixtures.StationAcceptanceFixtures.지하철역_생성;
-import static kuit.subway.utils.fixtures.LineFixtures.노선_생성_요청;
+import static kuit.subway.utils.fixtures.LineFixtures.노선_요청;
 import static kuit.subway.utils.fixtures.StationFixtures.지하철역_생성_요청;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -27,7 +27,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
 
         //when
         ExtractableResponse<Response> response =
-                노선_생성(노선_생성_요청("경춘선", "grean", 10L, 2L, 1L));
+                노선_생성(노선_요청("경춘선", "grean", 10L, 2L, 1L));
 
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
@@ -42,7 +42,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
 
         //when
         ExtractableResponse<Response> response =
-                노선_생성(노선_생성_요청("A".repeat(11),"G".repeat(11) , -1L, 2L, 1L));
+                노선_생성(노선_요청("A".repeat(11),"G".repeat(11) , -1L, 2L, 1L));
 
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
@@ -57,7 +57,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
 
         //when
         ExtractableResponse<Response> response =
-                노선_생성(노선_생성_요청("경춘선","grean" , 10L, 1L, 1L));
+                노선_생성(노선_요청("경춘선","grean" , 10L, 1L, 1L));
 
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
@@ -69,7 +69,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
         //given
         지하철역_생성(지하철역_생성_요청("강남역"));
         지하철역_생성(지하철역_생성_요청("성수역"));
-        노선_생성(노선_생성_요청("경춘선", "green", 10L, 1L, 2L));
+        노선_생성(노선_요청("경춘선", "green", 10L, 1L, 2L));
 
         //when
         ExtractableResponse<Response> response = 노선_조회(1L);
@@ -88,7 +88,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
         //given
         지하철역_생성(지하철역_생성_요청("강남역"));
         지하철역_생성(지하철역_생성_요청("성수역"));
-        노선_생성(노선_생성_요청("경춘선", "green", 10L, 1L, 2L));
+        노선_생성(노선_요청("경춘선", "green", 10L, 1L, 2L));
 
         //when
         ExtractableResponse<Response> response = 노선_조회(2L);

--- a/src/test/java/kuit/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/kuit/subway/acceptance/LineAcceptanceTest.java
@@ -6,11 +6,15 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
+import java.util.List;
+
 import static kuit.subway.acceptance.fixtures.LineAcceptanceFixtures.노선_생성;
+import static kuit.subway.acceptance.fixtures.LineAcceptanceFixtures.노선_조회;
 import static kuit.subway.acceptance.fixtures.StationAcceptanceFixtures.지하철역_생성;
 import static kuit.subway.utils.fixtures.LineFixtures.노선_생성_요청;
 import static kuit.subway.utils.fixtures.StationFixtures.지하철역_생성_요청;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class LineAcceptanceTest extends AcceptanceTest {
 
@@ -39,6 +43,40 @@ public class LineAcceptanceTest extends AcceptanceTest {
         //when
         ExtractableResponse<Response> response =
                 노선_생성(노선_생성_요청("A".repeat(11),"G".repeat(11) , -1L, 2L, 1L));
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @DisplayName("지하철 노선을 조회한다.")
+    @Test
+    void showLines(){
+        //given
+        지하철역_생성(지하철역_생성_요청("강남역"));
+        지하철역_생성(지하철역_생성_요청("성수역"));
+        노선_생성(노선_생성_요청("경춘선", "green", 10L, 1L, 2L));
+
+        //when
+        ExtractableResponse<Response> response = 노선_조회(1L);
+        List<Object> stations = response.jsonPath().getList("stations.");
+
+        //then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
+                () -> assertThat(stations).hasSize(2)
+        );
+    }
+
+    @DisplayName("존재하지 않는 지하철 노선을 조회시, 예외를 발생한다.")
+    @Test
+    void showLines_Throw_Exception_If_Not_Existed_Line(){
+        //given
+        지하철역_생성(지하철역_생성_요청("강남역"));
+        지하철역_생성(지하철역_생성_요청("성수역"));
+        노선_생성(노선_생성_요청("경춘선", "green", 10L, 1L, 2L));
+
+        //when
+        ExtractableResponse<Response> response = 노선_조회(2L);
 
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());

--- a/src/test/java/kuit/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/kuit/subway/acceptance/LineAcceptanceTest.java
@@ -48,6 +48,21 @@ public class LineAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 
+    @DisplayName("상행종점역과 하행종점역이 같은 노선 생성 요청의 경우, 예외를 발생한다.")
+    @Test
+    void createLine_Throw_Exception_If_Duplicated_Stations_Request(){
+        //given
+        지하철역_생성(지하철역_생성_요청("강남역"));
+        지하철역_생성(지하철역_생성_요청("성수역"));
+
+        //when
+        ExtractableResponse<Response> response =
+                노선_생성(노선_생성_요청("경춘선","grean" , 10L, 1L, 1L));
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
     @DisplayName("지하철 노선을 조회한다.")
     @Test
     void showLines(){

--- a/src/test/java/kuit/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/kuit/subway/acceptance/LineAcceptanceTest.java
@@ -8,8 +8,7 @@ import org.springframework.http.HttpStatus;
 
 import java.util.List;
 
-import static kuit.subway.acceptance.fixtures.LineAcceptanceFixtures.노선_생성;
-import static kuit.subway.acceptance.fixtures.LineAcceptanceFixtures.노선_조회;
+import static kuit.subway.acceptance.fixtures.LineAcceptanceFixtures.*;
 import static kuit.subway.acceptance.fixtures.StationAcceptanceFixtures.지하철역_생성;
 import static kuit.subway.utils.fixtures.LineFixtures.노선_요청;
 import static kuit.subway.utils.fixtures.StationFixtures.지하철역_생성_요청;
@@ -92,6 +91,36 @@ public class LineAcceptanceTest extends AcceptanceTest {
 
         //when
         ExtractableResponse<Response> response = 노선_조회(2L);
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @DisplayName("지하철 노선을 수정한다.")
+    @Test
+    void updateLine(){
+        //given
+        지하철역_생성(지하철역_생성_요청("강남역"));
+        지하철역_생성(지하철역_생성_요청("성수역"));
+        노선_생성(노선_요청("경춘선", "green", 10L, 1L, 2L));
+
+        //when
+        ExtractableResponse<Response> response = 노선_변경(1L, 노선_요청("신분당선", "red", 10L, 2L, 1L));
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @DisplayName("존재하지 않는 지하철 노선을 수정시, 예외를 발생한다.")
+    @Test
+    void updateLine_Throw_Exception_If_Not_Existed_Line(){
+        //given
+        지하철역_생성(지하철역_생성_요청("강남역"));
+        지하철역_생성(지하철역_생성_요청("성수역"));
+        노선_생성(노선_요청("경춘선", "green", 10L, 1L, 2L));
+
+        //when
+        ExtractableResponse<Response> response = 노선_변경(2L, 노선_요청("신분당선", "red", 10L, 2L, 1L));
 
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());

--- a/src/test/java/kuit/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/kuit/subway/acceptance/LineAcceptanceTest.java
@@ -25,8 +25,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
         지하철역_생성(지하철역_생성_요청("성수역"));
 
         //when
-        ExtractableResponse<Response> response =
-                노선_생성(노선_요청("경춘선", "grean", 10L, 2L, 1L));
+        ExtractableResponse<Response> response = 노선_생성(노선_요청("경춘선", "grean", 10L, 2L, 1L));
 
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());

--- a/src/test/java/kuit/subway/acceptance/fixtures/LineAcceptanceFixtures.java
+++ b/src/test/java/kuit/subway/acceptance/fixtures/LineAcceptanceFixtures.java
@@ -4,6 +4,7 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import kuit.subway.line.dto.request.LineCreateRequest;
 
+import static kuit.subway.utils.RestAssuredUtils.get;
 import static kuit.subway.utils.RestAssuredUtils.post;
 
 public class LineAcceptanceFixtures {
@@ -12,5 +13,9 @@ public class LineAcceptanceFixtures {
 
     public static ExtractableResponse<Response> 노선_생성(LineCreateRequest request) {
         return post(BASE_PATH, request);
+    }
+
+    public static ExtractableResponse<Response> 노선_조회(Long lineId) {
+        return get(BASE_PATH+"/{lineId}", lineId);
     }
 }

--- a/src/test/java/kuit/subway/acceptance/fixtures/LineAcceptanceFixtures.java
+++ b/src/test/java/kuit/subway/acceptance/fixtures/LineAcceptanceFixtures.java
@@ -4,8 +4,7 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import kuit.subway.line.dto.request.LineRequest;
 
-import static kuit.subway.utils.RestAssuredUtils.get;
-import static kuit.subway.utils.RestAssuredUtils.post;
+import static kuit.subway.utils.RestAssuredUtils.*;
 
 public class LineAcceptanceFixtures {
 
@@ -21,5 +20,9 @@ public class LineAcceptanceFixtures {
 
     public static ExtractableResponse<Response> 노선_변경(Long lineId, LineRequest request) {
         return post(request, BASE_PATH + "/{lineId}", lineId);
+    }
+
+    public static ExtractableResponse<Response> 노선_삭제(Long lineId) {
+        return delete(BASE_PATH + "/{lineId}", lineId);
     }
 }

--- a/src/test/java/kuit/subway/acceptance/fixtures/LineAcceptanceFixtures.java
+++ b/src/test/java/kuit/subway/acceptance/fixtures/LineAcceptanceFixtures.java
@@ -2,7 +2,7 @@ package kuit.subway.acceptance.fixtures;
 
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import kuit.subway.line.dto.request.LineCreateRequest;
+import kuit.subway.line.dto.request.LineRequest;
 
 import static kuit.subway.utils.RestAssuredUtils.get;
 import static kuit.subway.utils.RestAssuredUtils.post;
@@ -11,7 +11,7 @@ public class LineAcceptanceFixtures {
 
     private static final String BASE_PATH = "/lines";
 
-    public static ExtractableResponse<Response> 노선_생성(LineCreateRequest request) {
+    public static ExtractableResponse<Response> 노선_생성(LineRequest request) {
         return post(BASE_PATH, request);
     }
 

--- a/src/test/java/kuit/subway/acceptance/fixtures/LineAcceptanceFixtures.java
+++ b/src/test/java/kuit/subway/acceptance/fixtures/LineAcceptanceFixtures.java
@@ -1,0 +1,16 @@
+package kuit.subway.acceptance.fixtures;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import kuit.subway.line.dto.request.LineCreateRequest;
+
+import static kuit.subway.utils.RestAssuredUtils.post;
+
+public class LineAcceptanceFixtures {
+
+    private static final String BASE_PATH = "/lines";
+
+    public static ExtractableResponse<Response> 노선_생성(LineCreateRequest request) {
+        return post(BASE_PATH, request);
+    }
+}

--- a/src/test/java/kuit/subway/acceptance/fixtures/LineAcceptanceFixtures.java
+++ b/src/test/java/kuit/subway/acceptance/fixtures/LineAcceptanceFixtures.java
@@ -12,7 +12,7 @@ public class LineAcceptanceFixtures {
     private static final String BASE_PATH = "/lines";
 
     public static ExtractableResponse<Response> 노선_생성(LineRequest request) {
-        return post(BASE_PATH, request);
+        return post(request, BASE_PATH);
     }
 
     public static ExtractableResponse<Response> 노선_조회(Long lineId) {

--- a/src/test/java/kuit/subway/acceptance/fixtures/LineAcceptanceFixtures.java
+++ b/src/test/java/kuit/subway/acceptance/fixtures/LineAcceptanceFixtures.java
@@ -18,4 +18,8 @@ public class LineAcceptanceFixtures {
     public static ExtractableResponse<Response> 노선_조회(Long lineId) {
         return get(BASE_PATH+"/{lineId}", lineId);
     }
+
+    public static ExtractableResponse<Response> 노선_변경(Long lineId, LineRequest request) {
+        return post(request, BASE_PATH + "/{lineId}", lineId);
+    }
 }

--- a/src/test/java/kuit/subway/acceptance/fixtures/StationAcceptanceFixtures.java
+++ b/src/test/java/kuit/subway/acceptance/fixtures/StationAcceptanceFixtures.java
@@ -11,7 +11,7 @@ public class StationAcceptanceFixtures {
     private static final String BASE_PATH = "/stations";
 
     public static ExtractableResponse<Response> 지하철역_생성(StationCreateRequest request) {
-        return post(BASE_PATH, request);
+        return post(request, BASE_PATH);
     }
 
     public static ExtractableResponse<Response> 지하철역_조회() {

--- a/src/test/java/kuit/subway/utils/RestAssuredUtils.java
+++ b/src/test/java/kuit/subway/utils/RestAssuredUtils.java
@@ -7,7 +7,7 @@ import io.restassured.response.Response;
 
 public class RestAssuredUtils {
 
-    public static ExtractableResponse<Response> post(String path, Object requestBody) {
+    public static ExtractableResponse<Response> post(Object requestBody, String path) {
         return RestAssured
                 .given().log().all().body(requestBody)
                 .contentType(ContentType.JSON)
@@ -16,7 +16,7 @@ public class RestAssuredUtils {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> post(String path, Object requestBody, Object... pathParams) {
+    public static ExtractableResponse<Response> post(Object requestBody, String path, Object... pathParams) {
         return RestAssured
                 .given().log().all().body(requestBody)
                 .contentType(ContentType.JSON)
@@ -43,7 +43,7 @@ public class RestAssuredUtils {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> patch(String path, Object requestBody) {
+    public static ExtractableResponse<Response> patch(Object requestBody, String path) {
         return RestAssured
                 .given().log().all().body(requestBody)
                 .contentType(ContentType.JSON)
@@ -52,7 +52,7 @@ public class RestAssuredUtils {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> patch(String path, Object requestBody, Object... pathParams) {
+    public static ExtractableResponse<Response> patch(Object requestBody, String path, Object... pathParams) {
         return RestAssured
                 .given().log().all().body(requestBody)
                 .contentType(ContentType.JSON)

--- a/src/test/java/kuit/subway/utils/fixtures/LineFixtures.java
+++ b/src/test/java/kuit/subway/utils/fixtures/LineFixtures.java
@@ -4,7 +4,7 @@ import kuit.subway.line.dto.request.LineRequest;
 
 public class LineFixtures {
 
-    public static LineRequest 노선_생성_요청(String name, String color, Long distance, Long downStationId, Long upStationId) {
+    public static LineRequest 노선_요청(String name, String color, Long distance, Long downStationId, Long upStationId) {
         return LineRequest.builder()
                 .name(name)
                 .color(color)

--- a/src/test/java/kuit/subway/utils/fixtures/LineFixtures.java
+++ b/src/test/java/kuit/subway/utils/fixtures/LineFixtures.java
@@ -1,11 +1,11 @@
 package kuit.subway.utils.fixtures;
 
-import kuit.subway.line.dto.request.LineCreateRequest;
+import kuit.subway.line.dto.request.LineRequest;
 
 public class LineFixtures {
 
-    public static LineCreateRequest 노선_생성_요청(String name, String color, Long distance, Long downStationId, Long upStationId) {
-        return LineCreateRequest.builder()
+    public static LineRequest 노선_생성_요청(String name, String color, Long distance, Long downStationId, Long upStationId) {
+        return LineRequest.builder()
                 .name(name)
                 .color(color)
                 .distance(distance)

--- a/src/test/java/kuit/subway/utils/fixtures/LineFixtures.java
+++ b/src/test/java/kuit/subway/utils/fixtures/LineFixtures.java
@@ -4,11 +4,11 @@ import kuit.subway.line.dto.request.LineCreateRequest;
 
 public class LineFixtures {
 
-    public static LineCreateRequest 노선_생성_요청(String color, Long distance, String name, Long downStationId, Long upStationId) {
+    public static LineCreateRequest 노선_생성_요청(String name, String color, Long distance, Long downStationId, Long upStationId) {
         return LineCreateRequest.builder()
+                .name(name)
                 .color(color)
                 .distance(distance)
-                .name(name)
                 .downStationId(downStationId)
                 .upStationId(upStationId)
                 .build();

--- a/src/test/java/kuit/subway/utils/fixtures/LineFixtures.java
+++ b/src/test/java/kuit/subway/utils/fixtures/LineFixtures.java
@@ -1,0 +1,16 @@
+package kuit.subway.utils.fixtures;
+
+import kuit.subway.line.dto.request.LineCreateRequest;
+
+public class LineFixtures {
+
+    public static LineCreateRequest 노선_생성_요청(String color, Long distance, String name, Long downStationId, Long upStationId) {
+        return LineCreateRequest.builder()
+                .color(color)
+                .distance(distance)
+                .name(name)
+                .downStationId(downStationId)
+                .upStationId(upStationId)
+                .build();
+    }
+}


### PR DESCRIPTION
---

## 🛠️ **리팩토링**

먼저 귀중한 코드 리뷰에 무한한 감사를 드립니다.🥺
정우님 덕분에 코드를 어떻게 리팩토링하면 좋을지 깊게 생각하면서 조금이라도 성장할 수 있었습니다.😁

### 1. 프로젝트 구조 변경
메인 코드의 경우, 하나의 큰 도메인을 기준으로 하위에 Controller단, Service단 ... 등이 존재하는 구조로 리팩토링 하였습니다.
하지만, 인수 테스트의 경우, 하나의 도메인에 종속되기 보단 어느 영역에서도 사용될 수 있다고 생각하여 `acceptance` 디렉토리에서 이를 관리할 수 있도록 구조를 리팩토링하였습니다.

---

### 2. **예외 처리**
`@RestControllerAdvice`를 통해 예외처리를 하였으며, `enum` 타입의 `global.CustomExceptionStatus` 에서 `httpStatus` 및 `message`를 관리합니다.

이와 관련하여 테스트 코드에 대해 궁금한 것이 있습니다.

<img width="552" alt="image" src="https://github.com/KUIT-1/atdd-subway/assets/97597051/30226b71-4a2c-44c2-9be6-f43db46e4d53">

위와 같이 길이가 최소 2, 최대 20인 검증 조건이 존재할 때, 정우님께서는 최소 조건을 만족하지 못하는 경우와, 최대 조건을 만족하지 못하는 경우를 모두 테스트하시는지, 혹은 한 조건만을 테스트하시는지 궁금합니다 !

---

### 3. **RestAssuredUtils**
정우님께서 `RestAssured` 관련해서 중복된 코드가 발생할 수 있으므로, 리팩토링할 여지가 있다는 라뷰를 남겨주신 덕분에, 위와 같은 클래스를 통해 중복을 줄일 수 있었습니다. 이로 인한  장점과 단점은 다음과 같습니다.(지극히 주관적인 의견입니다 !)

😊 **장점**
1. 이후에 유사하게 사용되는 인수 테스트에 대해 해당 클래스의 메서드를 재사용할 수 있다.
2. 각각의 인수 테스트의 코드가 간결해진다.

😰 **단점**
1. 만약 `ContentType`이 다르는 등의 (`e.g. multipart`) 요청이 필요할 때마다 해당 클래스에서 정의해줘야한다.
2. 인수 테스트를 하며 무수히 많은 경우를 해당 클래스에서 관리하면 오히려 유지보수성이 떨어질 수 있다.

해당 클래스를 잘못 사용하는 경우, 배보다 배꼽이 커질 위험이 존재합니다.  위 클래스에 대해 정우님의 의견은 어떠신지, 그리고 정우님께서는 어떻게 중복을 줄이시는지 궁금합니다 !

---

### 4. **Fixtures**
인수 테스트, 즉 `RestAssured`와 관련된 Fixture 들은 `acceptance.fixtures` 디렉토리의 `xxxAcceptanceFixtures` 클래스로 관리하도록 변경하였습니다.
인수 테스트 이외의 다양한 곳에서 사용할 수 있는 Fixture 들은 `utils.fixtures` 디렉토리의 `xxxFixtures` 클래스로 관리하도록 변경하였습니다.

---

## ❗️ **배운점**
### 1. **`orphanremoval=true` 와 `Dirty checking`**
Step2에서, 지하철 노선 관련하여 조건이 추가되었습니다.
따라서, 역(N) - (1)노선 관계로 연관관계를 설정하고 매핑하였습니다.
이미 연관관계가 맺어진 노선을 삭제하기 위해서, `@OneToMany` 쪽에 `casecade`와 `orphanremoval`을 아래와 같이 설정하였습니다.

```java
    @OneToMany(mappedBy = "line", cascade = CascadeType.REMOVE, orphanRemoval = true)
    public List<Station> stations = new ArrayList<>();
```

하지만, 위와 같이 설정한 후, 노선 변경 Test에서 다음과 같은 에러가 발생하였습니다.
```java
org.hibernate.HibernateException: A collection with cascade="all-delete-orphan" was no longer referenced by the owning entity instance:
``` 

기존의 노선 변경을 위한 엔티티단의 비즈니스 메서드는 다음과 같습니다.
```java
// 리팩토링 전
    public void updateStations(List<Station> stations) {
        this.stations = stations;
        addStations(stations);
}
```

이를 호출하는 Service단의 메서드는 다음과 같았습니다.
```java
    @Transactional
    public LineResponse updateLine(Long lineId, LineRequest request) {
        Line line = lineRepository.findById(lineId)
                .orElseThrow(() -> new SubwayException(NOT_EXISTED_LINE));

        validateDuplicatedStations(request);
        List<Station> stations = extractStationsFrom(request);

        line.updateInfo(request.getName(), request.getColor(), request.getDistance());
        line.updateStations(stations);

        List<StationResponse> stationResponses = stations.stream().map(StationResponse::of).toList();

        return LineResponse.of(line, stationResponses);
    }
```

즉, `request`로부터 `id`값을 받아와 `List`로 변환한 후, 이를 `updateStations()`의 인자로 넘겨주는 방식으로 구현했습니다.
처음에 생각하기엔 JPA 더티 채킹을 하는 과정에서 새로운 리스트를 받으면, 이를 제대로 반영할 줄 알고 위와 같이 코드를 짰습니다.😅
하지만 위와 같이 새로운 리스트(e.g. hashcode등이 다른..)를 필드로 대체하는 경우, JPA 더티채킹 과정에서 이를 트래킹하지 못하기에 에러가 발생하게 되었습니다.
이를 해결하기 위해서, 새로운 리스트로 반환받지 않고, 아래의 코드처럼 기존의 리스트를 초기화한 후, `addAll()` 메서드를 통해 값을 채우니 정상적으로 작동하게 되었습니다.

```java
// 리팩토링 후
    public void updateStations(List<Station> stations) {
        this.stations.clear();
        this.stations.addAll(stations);
        addStations(stations);
    }
```

---

## ❓ **궁금한점**
### 1. **하나의 Response에 다른 Response가 껴있는 경우**
노선 조회 response의 경우, 다음과 같습니다.
```json
{
    "id": 1,
    "name": "경춘선",
    "color": "green",
    "stations": [
        {
            "id": 1,
            "name": "강남역"
        },
        {
            "id": 2,
            "name": "성수역"
        }
    ],
    "createdDate": "2023-08-03T16:42:21.390429",
    "modifiedDate": "2023-08-03T16:42:21.390429"
}
```

이때 `stations`를, `List<StationResponse>` 를 통해 반환하도록 구현하였으며, 이를 위한 생성메서드(`of()`)의 파라미터로 `List<StationResponse> stations`을 받도록 다음과 같이 구현하였습니다.

```java
@Builder
@Getter
public class LineResponse {

    private Long id;
    private String name;
    private String color;
    private List<StationResponse> stations;
    private LocalDateTime createdDate;
    private LocalDateTime modifiedDate;

    public static LineResponse of(Line line, List<StationResponse> stations) {
        return LineResponse.builder()
                .id(line.getId())
                .name(line.getName())
                .color(line.getColor())
                .stations(stations)
                .createdDate(line.getCreatedDate())
                .modifiedDate(line.getModifiedDate())
                .build();
    }
}
```

저는 Service단에서 `lineId`를 통해 `Line`을 조회한 다음, `getStations()`에 대한 스트림을 통해 DTO로 변환하는 작업을 진행하였습니다.

```java
// LineService
public LineResponse showLine(Long lineId) {
        Line line = lineRepository.findById(lineId)
                .orElseThrow(() -> new SubwayException(NOT_EXISTED_LINE));

        List<StationResponse> stationResponses = line.getStations().stream()
                .map(StationResponse::of)
                .toList();

        return LineResponse.of(line, stationResponses);
    }
```

이때 궁금한 점은, ResponseDto 내에 또다시 다른 Dto가 포함되는 경우, 이러한 변환작업을 Service단에서 처리하여 인자로 넘기는 방법과 파라미터 대신 Dto 생성 메서드에서 아래와 같이 반환하는 방법 중, 정우님은 어느 방법을 선호하는지 궁금합니다 !

```java
// LineResponse 내에서 변환
    public static LineResponse of(Line line) {
        List<StationResponse> stations = line.getStations().stream().map(StationResponse::of).toList();
        return LineResponse.builder()
                .id(line.getId())
                .name(line.getName())
                .color(line.getColor())
                .stations(stations)
                .createdDate(line.getCreatedDate())
                .modifiedDate(line.getModifiedDate())
                .build();
    }
```