### PR TITLE
[1차 과제 - Step2] 이재현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured'
-    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.6'
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 
     implementation 'com.google.guava:guava:31.1-jre'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured'
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.6'
 
     implementation 'com.google.guava:guava:31.1-jre'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured'
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
-
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.google.guava:guava:31.1-jre'
 }
 

--- a/src/main/java/kuit/subway/SubwayApplication.java
+++ b/src/main/java/kuit/subway/SubwayApplication.java
@@ -2,7 +2,9 @@ package kuit.subway;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class SubwayApplication {
 

--- a/src/main/java/kuit/subway/controller/ControllerAdvice.java
+++ b/src/main/java/kuit/subway/controller/ControllerAdvice.java
@@ -6,13 +6,27 @@ import kuit.subway.exception.SubwayException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Objects;
 
 @Slf4j
 @RequiredArgsConstructor
 @RestControllerAdvice
 public class ControllerAdvice {
+    private final int INVALID_INPUT_VALUE = 400;
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleInputFieldException(MethodArgumentNotValidException e) {
+        FieldError mainError = e.getFieldErrors().get(0);
+        String[] errorInfo = Objects.requireNonNull(mainError.getDefaultMessage()).split(":");
+        String message = errorInfo[0];
+        return ResponseEntity.badRequest().body(new ErrorResponse(INVALID_INPUT_VALUE, message));
+    }
+
     @ExceptionHandler(SubwayException.class)
     public ResponseEntity<ErrorResponse> handleSubwayException(SubwayException e) {
         return ResponseEntity.status(e.getHttpStatus()).body(new ErrorResponse(e.getCode(), e.getMessage()));

--- a/src/main/java/kuit/subway/controller/ControllerAdvice.java
+++ b/src/main/java/kuit/subway/controller/ControllerAdvice.java
@@ -1,0 +1,31 @@
+package kuit.subway.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import kuit.subway.dto.response.ErrorResponse;
+import kuit.subway.exception.SubwayException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestControllerAdvice
+public class ControllerAdvice {
+    @ExceptionHandler(SubwayException.class)
+    public ResponseEntity<ErrorResponse> handleSubwayException(SubwayException e) {
+        return ResponseEntity.status(e.getHttpStatus()).body(new ErrorResponse(e.getCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> unhandledException(Exception e, HttpServletRequest request) {
+        log.error("UnhandledException: {} {} error Message={} ",
+                request.getMethod(),
+                request.getRequestURI(),
+                e.getMessage());
+        return ResponseEntity.internalServerError()
+                .body(new ErrorResponse(9999, "일시적으로 접속이 원활하지 않습니다."));
+    }
+
+}

--- a/src/main/java/kuit/subway/controller/LineController.java
+++ b/src/main/java/kuit/subway/controller/LineController.java
@@ -1,0 +1,32 @@
+package kuit.subway.controller;
+
+import jakarta.validation.Valid;
+import kuit.subway.dto.request.CreateLineRequest;
+import kuit.subway.dto.response.CreateLineResponse;
+import kuit.subway.service.LineService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/lines")
+@RestController
+public class LineController {
+    private final LineService lineService;
+
+    @PostMapping
+    public ResponseEntity<CreateLineResponse> createLine(
+            @RequestBody @Valid CreateLineRequest request) {
+        log.info("노선 생성 API 를 호출합니다.");
+        CreateLineResponse response = lineService.createOne(request);
+        return ResponseEntity.created(
+                URI.create("/lines/" + response.getId())).body(response);
+    }
+}

--- a/src/main/java/kuit/subway/controller/LineController.java
+++ b/src/main/java/kuit/subway/controller/LineController.java
@@ -2,8 +2,10 @@ package kuit.subway.controller;
 
 import jakarta.validation.Valid;
 import kuit.subway.dto.request.CreateLineRequest;
+import kuit.subway.dto.request.ModifyLineRequest;
 import kuit.subway.dto.response.CreateLineResponse;
 import kuit.subway.dto.response.LineInfoResponse;
+import kuit.subway.dto.response.ModifyLineResponse;
 import kuit.subway.service.LineService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,5 +34,15 @@ public class LineController {
     public ResponseEntity<LineInfoResponse> getLineInfo(@PathVariable("id") Long id) {
         log.info("노선{id=" + id + "} 조회 API 를 호출합니다.");
         return ResponseEntity.ok(lineService.getLineDetails(id));
+    }
+
+    @PostMapping("/{id}")
+    public ResponseEntity<ModifyLineResponse> modifyLine(
+            @PathVariable("id") Long id,
+            @RequestBody @Valid ModifyLineRequest request) {
+        log.info("노선{id=" + id + "} 수정 API 를 호출합니다.");
+        ModifyLineResponse response = lineService.updateLine(request, id);
+        return ResponseEntity.created(
+                URI.create("/lines/" + response.getId())).body(response);
     }
 }

--- a/src/main/java/kuit/subway/controller/LineController.java
+++ b/src/main/java/kuit/subway/controller/LineController.java
@@ -4,11 +4,13 @@ import jakarta.validation.Valid;
 import kuit.subway.dto.request.CreateLineRequest;
 import kuit.subway.dto.request.ModifyLineRequest;
 import kuit.subway.dto.response.CreateLineResponse;
+import kuit.subway.dto.response.DeleteLineResponse;
 import kuit.subway.dto.response.LineInfoResponse;
 import kuit.subway.dto.response.ModifyLineResponse;
 import kuit.subway.service.LineService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -45,4 +47,14 @@ public class LineController {
         return ResponseEntity.created(
                 URI.create("/lines/" + response.getId())).body(response);
     }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<DeleteLineResponse> deleteLine(@PathVariable("id") Long id) {
+        log.info("노선{id=" + id + "} 삭제 API 를 호출합니다.");
+        DeleteLineResponse response = lineService.deleteLine(id);
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .body(response);
+    }
+
 }

--- a/src/main/java/kuit/subway/controller/LineController.java
+++ b/src/main/java/kuit/subway/controller/LineController.java
@@ -3,14 +3,12 @@ package kuit.subway.controller;
 import jakarta.validation.Valid;
 import kuit.subway.dto.request.CreateLineRequest;
 import kuit.subway.dto.response.CreateLineResponse;
+import kuit.subway.dto.response.LineInfoResponse;
 import kuit.subway.service.LineService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -28,5 +26,11 @@ public class LineController {
         CreateLineResponse response = lineService.createOne(request);
         return ResponseEntity.created(
                 URI.create("/lines/" + response.getId())).body(response);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<LineInfoResponse> getLineInfo(@PathVariable("id") Long id) {
+        log.info("노선{id=" + id + "} 조회 API 를 호출합니다.");
+        return ResponseEntity.ok(lineService.getLineDetails(id));
     }
 }

--- a/src/main/java/kuit/subway/controller/StationController.java
+++ b/src/main/java/kuit/subway/controller/StationController.java
@@ -32,9 +32,6 @@ public class StationController {
     public ResponseEntity<StationListResponse> getStations() {
         log.info("[지하철 목록 조회 API 를 호출합니다.]");
         StationListResponse response = stationService.getStations();
-        if (response.getStations().isEmpty()) {
-            return ResponseEntity.noContent().build();
-        }
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/kuit/subway/controller/StationController.java
+++ b/src/main/java/kuit/subway/controller/StationController.java
@@ -2,6 +2,7 @@ package kuit.subway.controller;
 
 import kuit.subway.dto.request.CreateStationRequest;
 import kuit.subway.dto.response.CreateStationResponse;
+import kuit.subway.dto.response.DeleteStationResponse;
 import kuit.subway.dto.response.StationListResponse;
 import kuit.subway.service.StationService;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,14 @@ public class StationController {
     public ResponseEntity<StationListResponse> getStations() {
         log.info("[지하철 목록 조회 API 를 호출합니다.]");
         StationListResponse response = stationService.getStations();
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<DeleteStationResponse> deleteStation(@PathVariable("id") Long id) {
+        log.info("[지하철 삭제(id=" + id + ") API 를 호출합니다.");
+        Long deletedId = stationService.deleteStation(id);
+        DeleteStationResponse response = new DeleteStationResponse(deletedId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/kuit/subway/controller/StationController.java
+++ b/src/main/java/kuit/subway/controller/StationController.java
@@ -1,5 +1,6 @@
 package kuit.subway.controller;
 
+import jakarta.validation.Valid;
 import kuit.subway.dto.request.CreateStationRequest;
 import kuit.subway.dto.response.CreateStationResponse;
 import kuit.subway.dto.response.DeleteStationResponse;
@@ -20,7 +21,7 @@ public class StationController {
 
     @PostMapping
     public ResponseEntity<CreateStationResponse> createStation(
-            @RequestBody CreateStationRequest request
+            @RequestBody @Valid CreateStationRequest request
     ) {
         String name = request.getName();
         log.info("[지하철 " + name + " 역 생성 API 를 호출합니다.]");

--- a/src/main/java/kuit/subway/controller/StationController.java
+++ b/src/main/java/kuit/subway/controller/StationController.java
@@ -1,0 +1,13 @@
+package kuit.subway.controller;
+
+import kuit.subway.service.StationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/stations")
+@RestController
+public class StationController {
+    private final StationService stationService;
+}

--- a/src/main/java/kuit/subway/controller/StationController.java
+++ b/src/main/java/kuit/subway/controller/StationController.java
@@ -2,14 +2,12 @@ package kuit.subway.controller;
 
 import kuit.subway.dto.request.CreateStationRequest;
 import kuit.subway.dto.response.CreateStationResponse;
+import kuit.subway.dto.response.StationListResponse;
 import kuit.subway.service.StationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -25,6 +23,13 @@ public class StationController {
         String name = request.getName();
         log.info("[지하철 " + name + " 역 생성 API 를 호출합니다.]");
         CreateStationResponse response = stationService.createOne(name);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<StationListResponse> getStations() {
+        log.info("[지하철 목록 조회 API 를 호출합니다.]");
+        StationListResponse response = stationService.getStations();
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/kuit/subway/controller/StationController.java
+++ b/src/main/java/kuit/subway/controller/StationController.java
@@ -1,13 +1,30 @@
 package kuit.subway.controller;
 
+import kuit.subway.dto.request.CreateStationRequest;
+import kuit.subway.dto.response.CreateStationResponse;
 import kuit.subway.service.StationService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/stations")
 @RestController
 public class StationController {
     private final StationService stationService;
+
+    @PostMapping
+    public ResponseEntity<CreateStationResponse> createStation(
+            @RequestBody CreateStationRequest request
+    ) {
+        String name = request.getName();
+        log.info("[지하철 " + name + " 역 생성 API 를 호출합니다.]");
+        CreateStationResponse response = stationService.createOne(name);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/kuit/subway/controller/StationController.java
+++ b/src/main/java/kuit/subway/controller/StationController.java
@@ -31,6 +31,9 @@ public class StationController {
     public ResponseEntity<StationListResponse> getStations() {
         log.info("[지하철 목록 조회 API 를 호출합니다.]");
         StationListResponse response = stationService.getStations();
+        if (response.getStations().isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/kuit/subway/controller/StationController.java
+++ b/src/main/java/kuit/subway/controller/StationController.java
@@ -7,6 +7,7 @@ import kuit.subway.dto.response.StationListResponse;
 import kuit.subway.service.StationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -42,6 +43,8 @@ public class StationController {
         log.info("[지하철 삭제(id=" + id + ") API 를 호출합니다.");
         Long deletedId = stationService.deleteStation(id);
         DeleteStationResponse response = new DeleteStationResponse(deletedId);
-        return ResponseEntity.ok(response);
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .body(response);
     }
 }

--- a/src/main/java/kuit/subway/domain/BaseTimeEntity.java
+++ b/src/main/java/kuit/subway/domain/BaseTimeEntity.java
@@ -1,0 +1,21 @@
+package kuit.subway.domain;
+
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+    @CreatedDate
+    private LocalDateTime createdDate;
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+}

--- a/src/main/java/kuit/subway/domain/Line.java
+++ b/src/main/java/kuit/subway/domain/Line.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "LINE")
-public class Line extends BaseTimeEntity{
+public class Line extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -36,5 +36,25 @@ public class Line extends BaseTimeEntity{
         if (downStationId == upStationId) {
             throw new InvalidCreateLineException();
         }
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setDistance(int distance) {
+        this.distance = distance;
+    }
+
+    public void setColor(String color) {
+        this.color = color;
+    }
+
+    public void setDownStationId(Long downStationId) {
+        this.downStationId = downStationId;
+    }
+
+    public void setUpStationId(Long upStationId) {
+        this.upStationId = upStationId;
     }
 }

--- a/src/main/java/kuit/subway/domain/Line.java
+++ b/src/main/java/kuit/subway/domain/Line.java
@@ -1,0 +1,40 @@
+package kuit.subway.domain;
+
+import jakarta.persistence.*;
+import kuit.subway.exception.badrequest.InvalidCreateLineException;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "LINE")
+public class Line {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(length = 20, nullable = false)
+    private String name;
+    private int distance;
+    private Long downStationId;
+    private Long upStationId;
+    private String color;
+
+    @Builder
+    public Line(String name, int distance, Long downStationId, Long upStationId, String color) {
+        validateStations(downStationId, upStationId);
+        this.name = name;
+        this.distance = distance;
+        this.downStationId = downStationId;
+        this.upStationId = upStationId;
+        this.color = color;
+    }
+
+    public void validateStations(Long downStationId, Long upStationId) {
+        if (downStationId == upStationId) {
+            throw new InvalidCreateLineException();
+        }
+    }
+}

--- a/src/main/java/kuit/subway/domain/Line.java
+++ b/src/main/java/kuit/subway/domain/Line.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "LINE")
-public class Line {
+public class Line extends BaseTimeEntity{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/kuit/subway/domain/Station.java
+++ b/src/main/java/kuit/subway/domain/Station.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "STATION")
-public class Station {
+public class Station extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/kuit/subway/domain/Station.java
+++ b/src/main/java/kuit/subway/domain/Station.java
@@ -1,0 +1,24 @@
+package kuit.subway.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "STATION")
+public class Station {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(length = 20, nullable = false)
+    private String name;
+
+    @Builder
+    public Station(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/kuit/subway/dto/request/CreateLineRequest.java
+++ b/src/main/java/kuit/subway/dto/request/CreateLineRequest.java
@@ -1,0 +1,23 @@
+package kuit.subway.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class CreateLineRequest {
+    @NotNull(message = "지하철 노선의 색상은 Null 일 수 없습니다.")
+    private String color;
+    @NotNull(message = "지하철 노선의 거리는 Null 일 수 없습니다.")
+    private int distance;
+    @Size(min = 3, max = 20)
+    private String name;
+    @NotNull(message = "지하철 노선의 하행 종점역은 정의되어야 합니다.")
+    Long downStationId;
+    @NotNull(message = "지하철 노선의 상행 종점역은 정의되어야 합니다.")
+    Long upStationId;
+}

--- a/src/main/java/kuit/subway/dto/request/CreateStationRequest.java
+++ b/src/main/java/kuit/subway/dto/request/CreateStationRequest.java
@@ -1,7 +1,11 @@
 package kuit.subway.dto.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
+@AllArgsConstructor
 @Data
 public class CreateStationRequest {
     private String name;

--- a/src/main/java/kuit/subway/dto/request/CreateStationRequest.java
+++ b/src/main/java/kuit/subway/dto/request/CreateStationRequest.java
@@ -1,5 +1,6 @@
 package kuit.subway.dto.request;
 
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,5 +9,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Data
 public class CreateStationRequest {
+    @Size(min = 3, max = 20)
     private String name;
 }

--- a/src/main/java/kuit/subway/dto/request/CreateStationRequest.java
+++ b/src/main/java/kuit/subway/dto/request/CreateStationRequest.java
@@ -1,0 +1,8 @@
+package kuit.subway.dto.request;
+
+import lombok.Data;
+
+@Data
+public class CreateStationRequest {
+    private String name;
+}

--- a/src/main/java/kuit/subway/dto/request/ModifyLineRequest.java
+++ b/src/main/java/kuit/subway/dto/request/ModifyLineRequest.java
@@ -1,0 +1,23 @@
+package kuit.subway.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class ModifyLineRequest {
+    @NotNull(message = "지하철 노선의 색상은 Null 일 수 없습니다.")
+    private String color;
+    @NotNull(message = "지하철 노선의 거리는 Null 일 수 없습니다.")
+    private int distance;
+    @Size(min = 3, max = 20)
+    private String name;
+    @NotNull(message = "지하철 노선의 하행 종점역은 정의되어야 합니다.")
+    Long downStationId;
+    @NotNull(message = "지하철 노선의 상행 종점역은 정의되어야 합니다.")
+    Long upStationId;
+}

--- a/src/main/java/kuit/subway/dto/response/CreateLineResponse.java
+++ b/src/main/java/kuit/subway/dto/response/CreateLineResponse.java
@@ -1,0 +1,12 @@
+package kuit.subway.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class CreateLineResponse {
+    private Long id;
+}

--- a/src/main/java/kuit/subway/dto/response/CreateStationResponse.java
+++ b/src/main/java/kuit/subway/dto/response/CreateStationResponse.java
@@ -1,0 +1,8 @@
+package kuit.subway.dto.response;
+
+import lombok.Data;
+
+@Data
+public class CreateStationResponse {
+    private Long id;
+}

--- a/src/main/java/kuit/subway/dto/response/CreateStationResponse.java
+++ b/src/main/java/kuit/subway/dto/response/CreateStationResponse.java
@@ -1,7 +1,11 @@
 package kuit.subway.dto.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
+@AllArgsConstructor
 @Data
 public class CreateStationResponse {
     private Long id;

--- a/src/main/java/kuit/subway/dto/response/DeleteLineResponse.java
+++ b/src/main/java/kuit/subway/dto/response/DeleteLineResponse.java
@@ -1,0 +1,12 @@
+package kuit.subway.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class DeleteLineResponse {
+    private Long id;
+}

--- a/src/main/java/kuit/subway/dto/response/DeleteStationResponse.java
+++ b/src/main/java/kuit/subway/dto/response/DeleteStationResponse.java
@@ -1,0 +1,12 @@
+package kuit.subway.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class DeleteStationResponse {
+    private Long id;
+}

--- a/src/main/java/kuit/subway/dto/response/ErrorResponse.java
+++ b/src/main/java/kuit/subway/dto/response/ErrorResponse.java
@@ -1,0 +1,12 @@
+package kuit.subway.dto.response;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class ErrorResponse {
+    private int code;
+    private String message;
+}

--- a/src/main/java/kuit/subway/dto/response/LineInfoResponse.java
+++ b/src/main/java/kuit/subway/dto/response/LineInfoResponse.java
@@ -1,0 +1,33 @@
+package kuit.subway.dto.response;
+
+import kuit.subway.domain.Line;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class LineInfoResponse {
+    private Long id;
+    private String name;
+    private String color;
+    private List<StationDto> stations;
+    private LocalDateTime createdDate;
+    private LocalDateTime modifiedDate;
+
+    private LineInfoResponse(Line line, List<StationDto> stations) {
+        this.id = line.getId();
+        this.name = line.getName();
+        this.color = line.getColor();
+        this.stations = stations;
+        this.createdDate = line.getCreatedDate();
+        this.modifiedDate = line.getModifiedDate();
+    }
+
+    public static LineInfoResponse from(Line line, List<StationDto> stations) {
+        return new LineInfoResponse(line, stations);
+    }
+}

--- a/src/main/java/kuit/subway/dto/response/ModifyLineResponse.java
+++ b/src/main/java/kuit/subway/dto/response/ModifyLineResponse.java
@@ -1,0 +1,19 @@
+package kuit.subway.dto.response;
+
+import kuit.subway.domain.Line;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Data
+public class ModifyLineResponse {
+    private Long id;
+
+    private ModifyLineResponse(Line line) {
+        this.id = line.getId();
+    }
+
+    public static ModifyLineResponse from(Line line) {
+        return new ModifyLineResponse(line);
+    }
+}

--- a/src/main/java/kuit/subway/dto/response/StationDto.java
+++ b/src/main/java/kuit/subway/dto/response/StationDto.java
@@ -12,7 +12,7 @@ public class StationDto {
     private Long id;
     private String name;
 
-    public StationDto(Station station) {
+    private StationDto(Station station) {
         this.id = station.getId();
         this.name = station.getName();
     }

--- a/src/main/java/kuit/subway/dto/response/StationDto.java
+++ b/src/main/java/kuit/subway/dto/response/StationDto.java
@@ -16,4 +16,8 @@ public class StationDto {
         this.id = station.getId();
         this.name = station.getName();
     }
+
+    public static StationDto from(Station station) {
+        return new StationDto(station);
+    }
 }

--- a/src/main/java/kuit/subway/dto/response/StationDto.java
+++ b/src/main/java/kuit/subway/dto/response/StationDto.java
@@ -1,0 +1,19 @@
+package kuit.subway.dto.response;
+
+import kuit.subway.domain.Station;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class StationDto {
+    private Long id;
+    private String name;
+
+    public StationDto(Station station) {
+        this.id = station.getId();
+        this.name = station.getName();
+    }
+}

--- a/src/main/java/kuit/subway/dto/response/StationListResponse.java
+++ b/src/main/java/kuit/subway/dto/response/StationListResponse.java
@@ -1,0 +1,14 @@
+package kuit.subway.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class StationListResponse {
+    private List<StationDto> stations;
+}

--- a/src/main/java/kuit/subway/exception/SubwayException.java
+++ b/src/main/java/kuit/subway/exception/SubwayException.java
@@ -1,0 +1,17 @@
+package kuit.subway.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class SubwayException extends RuntimeException {
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final int code;
+
+    public SubwayException(HttpStatus httpStatus, String message, int code) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+        this.code = code;
+    }
+}

--- a/src/main/java/kuit/subway/exception/badrequest/BadRequestException.java
+++ b/src/main/java/kuit/subway/exception/badrequest/BadRequestException.java
@@ -1,0 +1,12 @@
+package kuit.subway.exception.badrequest;
+
+import kuit.subway.exception.SubwayException;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class BadRequestException extends SubwayException {
+    public BadRequestException(String message, int code) {
+        super(HttpStatus.BAD_REQUEST, message, code);
+    }
+}

--- a/src/main/java/kuit/subway/exception/badrequest/DuplicatedLineNameException.java
+++ b/src/main/java/kuit/subway/exception/badrequest/DuplicatedLineNameException.java
@@ -1,0 +1,7 @@
+package kuit.subway.exception.badrequest;
+
+public class DuplicatedLineNameException extends BadRequestException {
+    public DuplicatedLineNameException() {
+        super("지하철 노선 이름이 중복된 값입니다.", 3002);
+    }
+}

--- a/src/main/java/kuit/subway/exception/badrequest/DuplicatedStationNameException.java
+++ b/src/main/java/kuit/subway/exception/badrequest/DuplicatedStationNameException.java
@@ -1,0 +1,7 @@
+package kuit.subway.exception.badrequest;
+
+public class DuplicatedStationNameException extends BadRequestException {
+    public DuplicatedStationNameException(){
+        super("이미 존재하는 지하철 역 이름입니다.", 3000);
+    }
+}

--- a/src/main/java/kuit/subway/exception/badrequest/InvalidCreateLineException.java
+++ b/src/main/java/kuit/subway/exception/badrequest/InvalidCreateLineException.java
@@ -1,0 +1,7 @@
+package kuit.subway.exception.badrequest;
+
+public class InvalidCreateLineException extends BadRequestException {
+    public InvalidCreateLineException(){
+        super("상행 종점역과 하행 종점역은 같을 수 없습니다.", 3001);
+    }
+}

--- a/src/main/java/kuit/subway/exception/notfound/NotFoundException.java
+++ b/src/main/java/kuit/subway/exception/notfound/NotFoundException.java
@@ -1,0 +1,12 @@
+package kuit.subway.exception.notfound;
+
+import kuit.subway.exception.SubwayException;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class NotFoundException extends SubwayException {
+    public NotFoundException(String message, int code) {
+        super(HttpStatus.NOT_FOUND, message, code);
+    }
+}

--- a/src/main/java/kuit/subway/exception/notfound/NotFoundLineException.java
+++ b/src/main/java/kuit/subway/exception/notfound/NotFoundLineException.java
@@ -1,0 +1,7 @@
+package kuit.subway.exception.notfound;
+
+public class NotFoundLineException extends NotFoundException {
+    public NotFoundLineException() {
+        super("존재하지 않는 지하철 노선입니다.", 2001);
+    }
+}

--- a/src/main/java/kuit/subway/exception/notfound/NotFoundStationException.java
+++ b/src/main/java/kuit/subway/exception/notfound/NotFoundStationException.java
@@ -1,0 +1,7 @@
+package kuit.subway.exception.notfound;
+
+public class NotFoundStationException extends NotFoundException {
+    public NotFoundStationException(){
+        super("존재하지 않는 지하철 역입니다.", 2000);
+    }
+}

--- a/src/main/java/kuit/subway/repository/LineRepository.java
+++ b/src/main/java/kuit/subway/repository/LineRepository.java
@@ -1,0 +1,8 @@
+package kuit.subway.repository;
+
+import kuit.subway.domain.Line;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LineRepository extends JpaRepository<Line, Long> {
+    boolean existsByName(String name);
+}

--- a/src/main/java/kuit/subway/repository/StationRepository.java
+++ b/src/main/java/kuit/subway/repository/StationRepository.java
@@ -1,0 +1,7 @@
+package kuit.subway.repository;
+
+import kuit.subway.domain.Station;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StationRepository extends JpaRepository<Station, Long> {
+}

--- a/src/main/java/kuit/subway/repository/StationRepository.java
+++ b/src/main/java/kuit/subway/repository/StationRepository.java
@@ -4,4 +4,5 @@ import kuit.subway.domain.Station;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StationRepository extends JpaRepository<Station, Long> {
+    boolean existsByName(String name);
 }

--- a/src/main/java/kuit/subway/service/LineService.java
+++ b/src/main/java/kuit/subway/service/LineService.java
@@ -3,11 +3,16 @@ package kuit.subway.service;
 import kuit.subway.domain.Line;
 import kuit.subway.dto.request.CreateLineRequest;
 import kuit.subway.dto.response.CreateLineResponse;
+import kuit.subway.dto.response.LineInfoResponse;
+import kuit.subway.dto.response.StationDto;
 import kuit.subway.exception.badrequest.DuplicatedLineNameException;
+import kuit.subway.exception.notfound.NotFoundLineException;
 import kuit.subway.repository.LineRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -30,13 +35,22 @@ public class LineService {
         return new CreateLineResponse(savedLineId);
     }
 
-    public void validateDuplicatedName(String name){
-        if(lineRepository.existsByName(name)){
+    public void validateDuplicatedName(String name) {
+        if (lineRepository.existsByName(name)) {
             throw new DuplicatedLineNameException();
         }
     }
-    public void validateStations(Long downStationId, Long upStationId){
+
+    public void validateStations(Long downStationId, Long upStationId) {
         stationService.validateInvalidStationId(downStationId);
         stationService.validateInvalidStationId(upStationId);
+    }
+
+    public LineInfoResponse getLineDetails(Long id) {
+        Line line = lineRepository.findById(id)
+                .orElseThrow(NotFoundLineException::new);
+        List<StationDto> stations =
+                stationService.getStationPair(line.getDownStationId(), line.getUpStationId());
+        return LineInfoResponse.from(line, stations);
     }
 }

--- a/src/main/java/kuit/subway/service/LineService.java
+++ b/src/main/java/kuit/subway/service/LineService.java
@@ -2,8 +2,10 @@ package kuit.subway.service;
 
 import kuit.subway.domain.Line;
 import kuit.subway.dto.request.CreateLineRequest;
+import kuit.subway.dto.request.ModifyLineRequest;
 import kuit.subway.dto.response.CreateLineResponse;
 import kuit.subway.dto.response.LineInfoResponse;
+import kuit.subway.dto.response.ModifyLineResponse;
 import kuit.subway.dto.response.StationDto;
 import kuit.subway.exception.badrequest.DuplicatedLineNameException;
 import kuit.subway.exception.notfound.NotFoundLineException;
@@ -52,5 +54,16 @@ public class LineService {
         List<StationDto> stations =
                 stationService.getStationPair(line.getDownStationId(), line.getUpStationId());
         return LineInfoResponse.from(line, stations);
+    }
+    @Transactional
+    public ModifyLineResponse updateLine(ModifyLineRequest request, Long id){
+        Line line = lineRepository.findById(id)
+                .orElseThrow(NotFoundLineException::new);
+        line.setColor(request.getColor());
+        line.setName(request.getName());
+        line.setDistance(request.getDistance());
+        line.setDownStationId(request.getDownStationId());
+        line.setUpStationId(request.getUpStationId());
+        return ModifyLineResponse.from(line);
     }
 }

--- a/src/main/java/kuit/subway/service/LineService.java
+++ b/src/main/java/kuit/subway/service/LineService.java
@@ -1,0 +1,42 @@
+package kuit.subway.service;
+
+import kuit.subway.domain.Line;
+import kuit.subway.dto.request.CreateLineRequest;
+import kuit.subway.dto.response.CreateLineResponse;
+import kuit.subway.exception.badrequest.DuplicatedLineNameException;
+import kuit.subway.repository.LineRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class LineService {
+    private final StationService stationService;
+    private final LineRepository lineRepository;
+
+    @Transactional
+    public CreateLineResponse createOne(CreateLineRequest request) {
+        validateStations(request.getDownStationId(), request.getUpStationId());
+        validateDuplicatedName(request.getName());
+        Long savedLineId = lineRepository.save(Line.builder()
+                .color(request.getColor())
+                .distance(request.getDistance())
+                .name(request.getName())
+                .downStationId(request.getDownStationId())
+                .upStationId(request.getUpStationId())
+                .build()).getId();
+        return new CreateLineResponse(savedLineId);
+    }
+
+    public void validateDuplicatedName(String name){
+        if(lineRepository.existsByName(name)){
+            throw new DuplicatedLineNameException();
+        }
+    }
+    public void validateStations(Long downStationId, Long upStationId){
+        stationService.validateInvalidStationId(downStationId);
+        stationService.validateInvalidStationId(upStationId);
+    }
+}

--- a/src/main/java/kuit/subway/service/LineService.java
+++ b/src/main/java/kuit/subway/service/LineService.java
@@ -3,10 +3,7 @@ package kuit.subway.service;
 import kuit.subway.domain.Line;
 import kuit.subway.dto.request.CreateLineRequest;
 import kuit.subway.dto.request.ModifyLineRequest;
-import kuit.subway.dto.response.CreateLineResponse;
-import kuit.subway.dto.response.LineInfoResponse;
-import kuit.subway.dto.response.ModifyLineResponse;
-import kuit.subway.dto.response.StationDto;
+import kuit.subway.dto.response.*;
 import kuit.subway.exception.badrequest.DuplicatedLineNameException;
 import kuit.subway.exception.notfound.NotFoundLineException;
 import kuit.subway.repository.LineRepository;
@@ -55,8 +52,9 @@ public class LineService {
                 stationService.getStationPair(line.getDownStationId(), line.getUpStationId());
         return LineInfoResponse.from(line, stations);
     }
+
     @Transactional
-    public ModifyLineResponse updateLine(ModifyLineRequest request, Long id){
+    public ModifyLineResponse updateLine(ModifyLineRequest request, Long id) {
         Line line = lineRepository.findById(id)
                 .orElseThrow(NotFoundLineException::new);
         line.setColor(request.getColor());
@@ -65,5 +63,13 @@ public class LineService {
         line.setDownStationId(request.getDownStationId());
         line.setUpStationId(request.getUpStationId());
         return ModifyLineResponse.from(line);
+    }
+
+    @Transactional
+    public DeleteLineResponse deleteLine(Long id) {
+        Line line = lineRepository.findById(id)
+                .orElseThrow(NotFoundLineException::new);
+        lineRepository.delete(line);
+        return new DeleteLineResponse(id);
     }
 }

--- a/src/main/java/kuit/subway/service/StationService.java
+++ b/src/main/java/kuit/subway/service/StationService.java
@@ -4,6 +4,7 @@ import kuit.subway.domain.Station;
 import kuit.subway.dto.response.CreateStationResponse;
 import kuit.subway.dto.response.StationDto;
 import kuit.subway.dto.response.StationListResponse;
+import kuit.subway.exception.badrequest.DuplicatedStationNameException;
 import kuit.subway.exception.notfound.NotFoundStationException;
 import kuit.subway.repository.StationRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ public class StationService {
 
     @Transactional
     public CreateStationResponse createOne(String name) {
+        validateDuplicatedName(name);
         Station savedStation = stationRepository.save(
                 Station.builder()
                         .name(name)
@@ -41,5 +43,10 @@ public class StationService {
                 .orElseThrow(NotFoundStationException::new);
         stationRepository.delete(station);
         return id;
+    }
+
+    public void validateDuplicatedName(String name){
+        if(stationRepository.existsByName(name))
+            throw new DuplicatedStationNameException();
     }
 }

--- a/src/main/java/kuit/subway/service/StationService.java
+++ b/src/main/java/kuit/subway/service/StationService.java
@@ -1,0 +1,13 @@
+package kuit.subway.service;
+
+import kuit.subway.repository.StationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class StationService {
+    private final StationRepository stationRepository;
+}

--- a/src/main/java/kuit/subway/service/StationService.java
+++ b/src/main/java/kuit/subway/service/StationService.java
@@ -45,13 +45,21 @@ public class StationService {
         return id;
     }
 
-    public void validateDuplicatedName(String name){
-        if(stationRepository.existsByName(name))
+    public void validateDuplicatedName(String name) {
+        if (stationRepository.existsByName(name))
             throw new DuplicatedStationNameException();
     }
 
-    public void validateInvalidStationId(Long id){
+    public void validateInvalidStationId(Long id) {
         stationRepository.findById(id)
                 .orElseThrow(NotFoundStationException::new);
+    }
+
+    public List<StationDto> getStationPair(Long downStationId, Long upStationId) {
+        Station downStation = stationRepository.findById(downStationId)
+                .orElseThrow(NotFoundStationException::new);
+        Station upStation = stationRepository.findById(upStationId)
+                .orElseThrow(NotFoundStationException::new);
+        return List.of(StationDto.from(downStation), StationDto.from(upStation));
     }
 }

--- a/src/main/java/kuit/subway/service/StationService.java
+++ b/src/main/java/kuit/subway/service/StationService.java
@@ -2,10 +2,14 @@ package kuit.subway.service;
 
 import kuit.subway.domain.Station;
 import kuit.subway.dto.response.CreateStationResponse;
+import kuit.subway.dto.response.StationDto;
+import kuit.subway.dto.response.StationListResponse;
 import kuit.subway.repository.StationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -20,5 +24,13 @@ public class StationService {
                         .name(name)
                         .build());
         return new CreateStationResponse(savedStation.getId());
+    }
+
+    public StationListResponse getStations() {
+        List<Station> savedStations = stationRepository.findAll();
+        List<StationDto> stations = savedStations.stream().map(
+                StationDto::new
+        ).toList();
+        return new StationListResponse(stations);
     }
 }

--- a/src/main/java/kuit/subway/service/StationService.java
+++ b/src/main/java/kuit/subway/service/StationService.java
@@ -1,5 +1,7 @@
 package kuit.subway.service;
 
+import kuit.subway.domain.Station;
+import kuit.subway.dto.response.CreateStationResponse;
 import kuit.subway.repository.StationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,4 +12,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class StationService {
     private final StationRepository stationRepository;
+
+    @Transactional
+    public CreateStationResponse createOne(String name) {
+        Station savedStation = stationRepository.save(
+                Station.builder()
+                        .name(name)
+                        .build());
+        return new CreateStationResponse(savedStation.getId());
+    }
 }

--- a/src/main/java/kuit/subway/service/StationService.java
+++ b/src/main/java/kuit/subway/service/StationService.java
@@ -33,4 +33,12 @@ public class StationService {
         ).toList();
         return new StationListResponse(stations);
     }
+
+    @Transactional
+    public Long deleteStation(Long id) {
+        Station station = stationRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 지하철 역을 찾을 수 없습니다."));
+        stationRepository.delete(station);
+        return id;
+    }
 }

--- a/src/main/java/kuit/subway/service/StationService.java
+++ b/src/main/java/kuit/subway/service/StationService.java
@@ -29,7 +29,7 @@ public class StationService {
     public StationListResponse getStations() {
         List<Station> savedStations = stationRepository.findAll();
         List<StationDto> stations = savedStations.stream().map(
-                StationDto::new
+                StationDto::from
         ).toList();
         return new StationListResponse(stations);
     }

--- a/src/main/java/kuit/subway/service/StationService.java
+++ b/src/main/java/kuit/subway/service/StationService.java
@@ -4,6 +4,7 @@ import kuit.subway.domain.Station;
 import kuit.subway.dto.response.CreateStationResponse;
 import kuit.subway.dto.response.StationDto;
 import kuit.subway.dto.response.StationListResponse;
+import kuit.subway.exception.notfound.NotFoundStationException;
 import kuit.subway.repository.StationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -37,7 +38,7 @@ public class StationService {
     @Transactional
     public Long deleteStation(Long id) {
         Station station = stationRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 지하철 역을 찾을 수 없습니다."));
+                .orElseThrow(NotFoundStationException::new);
         stationRepository.delete(station);
         return id;
     }

--- a/src/main/java/kuit/subway/service/StationService.java
+++ b/src/main/java/kuit/subway/service/StationService.java
@@ -49,4 +49,9 @@ public class StationService {
         if(stationRepository.existsByName(name))
             throw new DuplicatedStationNameException();
     }
+
+    public void validateInvalidStationId(Long id){
+        stationRepository.findById(id)
+                .orElseThrow(NotFoundStationException::new);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
       hibernate:
         create_empty_composites:
           enabled: true
-        #format_sql: true
+        format_sql: true
         default_batch_fetch_size: 100
   task:
     execution:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
       hibernate:
         create_empty_composites:
           enabled: true
-        format_sql: true
+        #format_sql: true
         default_batch_fetch_size: 100
   task:
     execution:
@@ -23,3 +23,8 @@ spring:
       enabled: true
       settings:
         web-allow-others: true
+
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: true

--- a/src/test/java/kuit/subway/AcceptanceTest.java
+++ b/src/test/java/kuit/subway/AcceptanceTest.java
@@ -19,7 +19,7 @@ public class AcceptanceTest {
 
     @BeforeEach
     public void setUp() {
-        RestAssured.port = 443;
+        RestAssured.port = port;
         databaseCleanup.execute();
     }
 }

--- a/src/test/java/kuit/subway/study/acceptance/AcceptanceFixture.java
+++ b/src/test/java/kuit/subway/study/acceptance/AcceptanceFixture.java
@@ -4,10 +4,12 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import kuit.subway.dto.request.CreateLineRequest;
 import kuit.subway.dto.request.CreateStationRequest;
 
 public class AcceptanceFixture {
     private static final String STATION_PATH = "/stations";
+    private static final String LINE_PATH = "/lines";
 
     public static ExtractableResponse<Response> 지하철_역_생성하기(CreateStationRequest request) {
         return RestAssured.given().log().all()
@@ -24,9 +26,16 @@ public class AcceptanceFixture {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> 지하철_역_삭제하기(int 지하철_역_아이디) {
+    public static ExtractableResponse<Response> 지하철_역_삭제하기(Long 지하철_역_아이디) {
         return RestAssured.given().log().all()
                 .when().delete(STATION_PATH + "/{id}", 지하철_역_아이디)
+                .then().log().all()
+                .extract();
+    }
+    public static ExtractableResponse<Response> 지하철_노선_생성하기(CreateLineRequest request) {
+        return RestAssured.given().log().all()
+                .body(request).contentType(ContentType.JSON)
+                .when().post(LINE_PATH)
                 .then().log().all()
                 .extract();
     }

--- a/src/test/java/kuit/subway/study/acceptance/AcceptanceFixture.java
+++ b/src/test/java/kuit/subway/study/acceptance/AcceptanceFixture.java
@@ -1,0 +1,33 @@
+package kuit.subway.study.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import kuit.subway.dto.request.CreateStationRequest;
+
+public class AcceptanceFixture {
+    private static final String STATION_PATH = "/stations";
+
+    public static ExtractableResponse<Response> 지하철_역_생성하기(CreateStationRequest request) {
+        return RestAssured.given().log().all()
+                .body(request).contentType(ContentType.JSON)
+                .when().post(STATION_PATH)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철_역_목록_조회하기() {
+        return RestAssured.given().log().all()
+                .when().get(STATION_PATH)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철_역_삭제하기(int 지하철_역_아이디) {
+        return RestAssured.given().log().all()
+                .when().delete(STATION_PATH + "/{id}", 지하철_역_아이디)
+                .then().log().all()
+                .extract();
+    }
+}

--- a/src/test/java/kuit/subway/study/acceptance/AcceptanceFixture.java
+++ b/src/test/java/kuit/subway/study/acceptance/AcceptanceFixture.java
@@ -6,6 +6,7 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import kuit.subway.dto.request.CreateLineRequest;
 import kuit.subway.dto.request.CreateStationRequest;
+import kuit.subway.dto.request.ModifyLineRequest;
 
 public class AcceptanceFixture {
     private static final String STATION_PATH = "/stations";
@@ -32,6 +33,7 @@ public class AcceptanceFixture {
                 .then().log().all()
                 .extract();
     }
+
     public static ExtractableResponse<Response> 지하철_노선_생성하기(CreateLineRequest request) {
         return RestAssured.given().log().all()
                 .body(request).contentType(ContentType.JSON)
@@ -43,6 +45,14 @@ public class AcceptanceFixture {
     public static ExtractableResponse<Response> 지하철_노선_조회하기(Long 지하철_노선_아이디) {
         return RestAssured.given().log().all()
                 .when().get(LINE_PATH + "/{id}", 지하철_노선_아이디)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_수정하기(ModifyLineRequest request, Long 지하철_노선_아이디) {
+        return RestAssured.given().log().all()
+                .body(request).contentType(ContentType.JSON)
+                .when().post(LINE_PATH + "/{id}", 지하철_노선_아이디)
                 .then().log().all()
                 .extract();
     }

--- a/src/test/java/kuit/subway/study/acceptance/AcceptanceFixture.java
+++ b/src/test/java/kuit/subway/study/acceptance/AcceptanceFixture.java
@@ -39,4 +39,11 @@ public class AcceptanceFixture {
                 .then().log().all()
                 .extract();
     }
+
+    public static ExtractableResponse<Response> 지하철_노선_조회하기(Long 지하철_노선_아이디) {
+        return RestAssured.given().log().all()
+                .when().get(LINE_PATH + "/{id}", 지하철_노선_아이디)
+                .then().log().all()
+                .extract();
+    }
 }

--- a/src/test/java/kuit/subway/study/acceptance/AcceptanceFixture.java
+++ b/src/test/java/kuit/subway/study/acceptance/AcceptanceFixture.java
@@ -56,4 +56,11 @@ public class AcceptanceFixture {
                 .then().log().all()
                 .extract();
     }
+
+    public static ExtractableResponse<Response> 지하철_노선_삭제하기(Long 지하철_노선_아이디) {
+        return RestAssured.given().log().all()
+                .when().delete(LINE_PATH + "/{id}", 지하철_노선_아이디)
+                .then().log().all()
+                .extract();
+    }
 }

--- a/src/test/java/kuit/subway/study/acceptance/StationFixData.java
+++ b/src/test/java/kuit/subway/study/acceptance/StationFixData.java
@@ -2,6 +2,7 @@ package kuit.subway.study.acceptance;
 
 import kuit.subway.dto.request.CreateLineRequest;
 import kuit.subway.dto.request.CreateStationRequest;
+import kuit.subway.dto.request.ModifyLineRequest;
 
 public class StationFixData {
     public static CreateStationRequest 지하철_역_생성_데이터(String name) {
@@ -10,5 +11,9 @@ public class StationFixData {
 
     public static CreateLineRequest 지하철_노선_생성_데이터(String name, String color, int distance, Long downStationId, Long upStationId) {
         return new CreateLineRequest(color, distance, name, downStationId, upStationId);
+    }
+
+    public static ModifyLineRequest 지하철_노선_수정_데이터(String name, String color, int distance, Long downStationId, Long upStationId) {
+        return new ModifyLineRequest(color, distance, name, downStationId, upStationId);
     }
 }

--- a/src/test/java/kuit/subway/study/acceptance/StationFixData.java
+++ b/src/test/java/kuit/subway/study/acceptance/StationFixData.java
@@ -4,16 +4,32 @@ import kuit.subway.dto.request.CreateLineRequest;
 import kuit.subway.dto.request.CreateStationRequest;
 import kuit.subway.dto.request.ModifyLineRequest;
 
+import static kuit.subway.study.acceptance.AcceptanceFixture.지하철_노선_생성하기;
+import static kuit.subway.study.acceptance.AcceptanceFixture.지하철_역_생성하기;
+
 public class StationFixData {
-    public static CreateStationRequest 지하철_역_생성_데이터(String name) {
+    public static CreateStationRequest 지하철_역_생성_데이터_만들기(String name) {
         return new CreateStationRequest(name);
     }
 
-    public static CreateLineRequest 지하철_노선_생성_데이터(String name, String color, int distance, Long downStationId, Long upStationId) {
+    public static CreateLineRequest 지하철_노선_생성_데이터_만들기(String name, String color, int distance, Long downStationId, Long upStationId) {
         return new CreateLineRequest(color, distance, name, downStationId, upStationId);
     }
 
-    public static ModifyLineRequest 지하철_노선_수정_데이터(String name, String color, int distance, Long downStationId, Long upStationId) {
+    public static ModifyLineRequest 지하철_노선_수정_데이터_만들기(String name, String color, int distance, Long downStationId, Long upStationId) {
         return new ModifyLineRequest(color, distance, name, downStationId, upStationId);
+    }
+
+    public static Long 이호선_노선_더미데이터_생성하기(Long downStationId, Long upStationId) {
+        CreateLineRequest 이호선 = 지하철_노선_생성_데이터_만들기("이호선", "green", 10, downStationId, upStationId);
+        지하철_노선_생성하기(이호선);
+        return 1L;
+    }
+
+    public static void 강남역_서초역_더미데이터_생성하기() {
+        CreateStationRequest 강남역 = 지하철_역_생성_데이터_만들기("강남역");
+        CreateStationRequest 서초역 = 지하철_역_생성_데이터_만들기("서초역");
+        지하철_역_생성하기(강남역);
+        지하철_역_생성하기(서초역);
     }
 }

--- a/src/test/java/kuit/subway/study/acceptance/StationFixData.java
+++ b/src/test/java/kuit/subway/study/acceptance/StationFixData.java
@@ -1,0 +1,9 @@
+package kuit.subway.study.acceptance;
+
+import kuit.subway.dto.request.CreateStationRequest;
+
+public class StationFixData {
+    public static CreateStationRequest 지하철_역_생성_데이터(String name){
+        return new CreateStationRequest(name);
+    }
+}

--- a/src/test/java/kuit/subway/study/acceptance/StationFixData.java
+++ b/src/test/java/kuit/subway/study/acceptance/StationFixData.java
@@ -1,9 +1,14 @@
 package kuit.subway.study.acceptance;
 
+import kuit.subway.dto.request.CreateLineRequest;
 import kuit.subway.dto.request.CreateStationRequest;
 
 public class StationFixData {
-    public static CreateStationRequest 지하철_역_생성_데이터(String name){
+    public static CreateStationRequest 지하철_역_생성_데이터(String name) {
         return new CreateStationRequest(name);
+    }
+
+    public static CreateLineRequest 지하철_노선_생성_데이터(String name, String color, int distance, Long downStationId, Long upStationId) {
+        return new CreateLineRequest(color, distance, name, downStationId, upStationId);
     }
 }

--- a/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
+++ b/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
@@ -6,10 +6,17 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import kuit.subway.AcceptanceTest;
 import kuit.subway.dto.request.CreateStationRequest;
+import kuit.subway.service.StationService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.hamcrest.Matchers.equalTo;
 
 public class SubwayTest extends AcceptanceTest {
+    @Autowired
+    StationService stationService;
+
     @Test
     public void 지하철_역_생성() {
         // given
@@ -22,5 +29,20 @@ public class SubwayTest extends AcceptanceTest {
                 .extract();
         // then
         Assertions.assertEquals(200, extract.statusCode());
+    }
+
+    @Test
+    public void 지하철_목록_조회() throws Exception {
+        // given Given 2개의 지하철역을 생성하고
+        stationService.createOne("강남역");
+        stationService.createOne("서초역");
+
+        // when 지하철 목록을 조회하면
+        // then 2 개의 지하철 역 목록을 응답받는다.
+        RestAssured.given().log().all()
+                .when().get("/stations")
+                .then().log().all()
+                .assertThat().body("stations.size()", equalTo(2))
+                .assertThat().statusCode(200);
     }
 }

--- a/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
+++ b/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
@@ -28,7 +28,7 @@ public class SubwayTest extends AcceptanceTest {
 
     @Description("생성된 지하철 역 목록이 올바르게 조회되어야 한다.")
     @Test
-    public void 지하철_목록_조회() {
+    public void 지하철_목록_조회_테스트 () {
         // given Given 2개의 지하철역을 생성하고
         CreateStationRequest 강남역_데이터 = 지하철_역_생성_데이터("강남역");
         CreateStationRequest 서초역_데이터 = 지하철_역_생성_데이터("서초역");
@@ -46,7 +46,7 @@ public class SubwayTest extends AcceptanceTest {
 
     @Description("생성된 지하철 역에 대한 삭제 요청 시, 해당 지하철 역은 목록에서 제거되어야 한다.")
     @Test
-    public void 지하철_삭제() {
+    public void 지하철_삭제_테스트 () {
         // given 지하철 역을 생성하고
         CreateStationRequest 강남역_데이터 = 지하철_역_생성_데이터("강남역");
         지하철_역_생성하기(강남역_데이터);
@@ -61,7 +61,7 @@ public class SubwayTest extends AcceptanceTest {
 
     @Description("올바르지 않은 이름으로 지하철 역 생성 요청 시, 거절되어야 한다.")
     @Test
-    public void 올바르지_않은_이름으로_지하철_역_생성() {
+    public void 올바르지_않은_이름으로_지하철_역_생성_테스트 () {
         // given 최소 길이보다 짧거나 최대 길이보다 긴 이름의 지하철 역 데이터로
         CreateStationRequest 최소길이보다_짧은_이름의_지하철역 = 지하철_역_생성_데이터("강역");
         CreateStationRequest 최대길이보다_긴_이름의_지하철역 = 지하철_역_생성_데이터("123456789.123456789.123456789");
@@ -78,7 +78,7 @@ public class SubwayTest extends AcceptanceTest {
 
     @Description("이미 존재하는 이름으로 지하철 역 생성 요청 시, 거절되어야 한다.")
     @Test
-    public void 이미존재하는_이름으로_지하철역_생성 () {
+    public void 이미존재하는_이름으로_지하철역_생성_테스트 () {
         // given "강남역" 지하철역이 이미 존재할 때
         CreateStationRequest 강남역_데이터 = 지하철_역_생성_데이터("강남역");
         지하철_역_생성하기(강남역_데이터);

--- a/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
+++ b/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
@@ -45,4 +45,13 @@ public class SubwayTest extends AcceptanceTest {
                 .assertThat().body("stations.size()", equalTo(2))
                 .assertThat().statusCode(200);
     }
+
+    @Test
+    public void 지하철_삭제() throws Exception {
+        // given 지하철 역을 생성하고
+        stationService.createOne("강남역");
+
+        // when 그 지하철 역을 삭제하면
+        // then 그 지하철 역 목록 조회 시 생성한 역을 찾을 수 없다.
+    }
 }

--- a/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
+++ b/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
@@ -208,6 +208,6 @@ public class SubwayTest extends AcceptanceTest {
         ExtractableResponse<Response> extract = 지하철_노선_조회하기(노선_아이디);
         // then 거절되어야 한다.
         extract.response().then().log().all()
-                .assertThat().statusCode(HttpStatus.BAD_REQUEST.value());
+                .assertThat().statusCode(HttpStatus.NOT_FOUND.value());
     }
 }

--- a/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
+++ b/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
@@ -17,6 +17,7 @@ import static kuit.subway.study.acceptance.StationFixData.지하철_역_생성_�
 import static org.hamcrest.Matchers.equalTo;
 
 public class SubwayTest extends AcceptanceTest {
+    private final int INVALID_INPUT_STATUS_CODE = 400;
     @Description("올바른 이름 요청 시 지하철 역이 정상적으로 생성되어야 한다.")
     @Test
     public void 지하철_역_생성_테스트() {
@@ -72,9 +73,9 @@ public class SubwayTest extends AcceptanceTest {
         ExtractableResponse<Response> extract2 = 지하철_역_생성하기(최대길이보다_긴_이름의_지하철역);
         // then 거절되어야 하고, 지하철 역 목록에 반영되면 안된다.
         extract1.response().then().log().all()
-                .assertThat().statusCode(400);
+                .assertThat().statusCode(INVALID_INPUT_STATUS_CODE);
         extract2.response().then().log().all()
-                .assertThat().statusCode(400);
+                .assertThat().statusCode(INVALID_INPUT_STATUS_CODE);
         지하철_역_목록_조회하기();
     }
 
@@ -88,7 +89,7 @@ public class SubwayTest extends AcceptanceTest {
         ExtractableResponse<Response> extract = 지하철_역_생성하기(강남역_데이터);
         // then 거절되어야 하고, 지하철 역 목록에 반영되면 안된다.
         extract.response().then().log().all()
-                .assertThat().statusCode(400);
+                .assertThat().statusCode(INVALID_INPUT_STATUS_CODE);
         지하철_역_목록_조회하기();
     }
 
@@ -174,6 +175,6 @@ public class SubwayTest extends AcceptanceTest {
         ExtractableResponse<Response> extract = 지하철_노선_생성하기(이호선_데이터);
         // then 거절되어야 한다.
         extract.response().then().log().all()
-                .assertThat().statusCode(400);
+                .assertThat().statusCode(INVALID_INPUT_STATUS_CODE);
     }
 }

--- a/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
+++ b/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
@@ -1,25 +1,23 @@
 package kuit.subway.study.acceptance;
 
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import kuit.subway.AcceptanceTest;
+import kuit.subway.dto.request.CreateStationRequest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class SubwayTest extends AcceptanceTest {
     @Test
     public void 지하철_역_생성() {
         // given
-        Map<String, String> body = new HashMap<>();
-        body.put("name", "강남역");
+        CreateStationRequest request = new CreateStationRequest("강남역");
         // when
         ExtractableResponse<Response> extract = RestAssured.given().log().all()
-                .body(body)
-                .when().post("stations")
+                .body(request).contentType(ContentType.JSON)
+                .when().post("/stations")
                 .then().log().all()
                 .extract();
         // then

--- a/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
+++ b/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
@@ -58,4 +58,21 @@ public class SubwayTest extends AcceptanceTest {
         int 응답_코드 = extract.statusCode();
         Assertions.assertEquals(HttpStatus.OK.value(), 응답_코드);
     }
+
+    @Description("올바르지 않은 이름으로 지하철 역 생성 요청 시, 거절되어야 한다.")
+    @Test
+    public void 올바르지_않은_이름으로_지하철_역_생성() {
+        // given 최소 길이보다 짧거나 최대 길이보다 긴 이름의 지하철 역 데이터로
+        CreateStationRequest 최소길이보다_짧은_이름의_지하철역 = 지하철_역_생성_데이터("강역");
+        CreateStationRequest 최대길이보다_긴_이름의_지하철역 = 지하철_역_생성_데이터("123456789.123456789.123456789");
+        // when 지하철 역 생성 요청 시
+        ExtractableResponse<Response> extract1 = 지하철_역_생성하기(최소길이보다_짧은_이름의_지하철역);
+        ExtractableResponse<Response> extract2 = 지하철_역_생성하기(최대길이보다_긴_이름의_지하철역);
+        // then 거절되어야 하고, 지하철 역 목록에 반영되면 안된다.
+        extract1.response().then().log().all()
+                .assertThat().statusCode(400);
+        extract2.response().then().log().all()
+                .assertThat().statusCode(400);
+        지하철_역_목록_조회하기();
+    }
 }

--- a/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
+++ b/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
@@ -4,6 +4,7 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import jdk.jfr.Description;
 import kuit.subway.AcceptanceTest;
 import kuit.subway.dto.request.CreateStationRequest;
 import kuit.subway.dto.response.CreateStationResponse;
@@ -18,7 +19,9 @@ import static org.hamcrest.Matchers.equalTo;
 public class SubwayTest extends AcceptanceTest {
     @Autowired
     StationService stationService;
+    private final String PATH = "/stations";
 
+    @Description("지하철 역 생성 API 인수 테스트")
     @Test
     public void 지하철_역_생성() {
         // given
@@ -26,15 +29,16 @@ public class SubwayTest extends AcceptanceTest {
         // when
         ExtractableResponse<Response> extract = RestAssured.given().log().all()
                 .body(request).contentType(ContentType.JSON)
-                .when().post("/stations")
+                .when().post(PATH)
                 .then().log().all()
                 .extract();
         // then
-        Assertions.assertEquals(200, extract.statusCode());
+        Assertions.assertEquals(HttpStatus.OK.value(), extract.statusCode());
     }
 
+    @Description("지하철 목록 조회 API 인수 테스트")
     @Test
-    public void 지하철_목록_조회() throws Exception {
+    public void 지하철_목록_조회() {
         // given Given 2개의 지하철역을 생성하고
         stationService.createOne("강남역");
         stationService.createOne("서초역");
@@ -42,26 +46,27 @@ public class SubwayTest extends AcceptanceTest {
         // when 지하철 목록을 조회하면
         // then 2 개의 지하철 역 목록을 응답받는다.
         RestAssured.given().log().all()
-                .when().get("/stations")
+                .when().get(PATH)
                 .then().log().all()
                 .assertThat().body("stations.size()", equalTo(2))
-                .assertThat().statusCode(200);
+                .assertThat().statusCode(HttpStatus.OK.value());
     }
 
+    @Description("지하철 삭제 API 인수 테스트")
     @Test
-    public void 지하철_삭제() throws Exception {
+    public void 지하철_삭제() {
         // given 지하철 역을 생성하고
         CreateStationResponse station = stationService.createOne("강남역");
 
         // when 그 지하철 역을 삭제하면
         RestAssured.given().log().all()
-                .when().delete("/stations/{id}", String.valueOf(station.getId()))
+                .when().delete(PATH + "/{id}", String.valueOf(station.getId()))
                 .then().log().all()
                 .assertThat().statusCode(HttpStatus.OK.value());
 
         // then 그 지하철 역 목록 조회 시 생성한 역을 찾을 수 없다.
         RestAssured.given().log().all()
-                .when().get("/stations")
+                .when().get(PATH)
                 .then().log().all()
                 .assertThat().statusCode(HttpStatus.NO_CONTENT.value());
     }

--- a/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
+++ b/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class SubwayTest extends AcceptanceTest {
     private final int INVALID_INPUT_STATUS_CODE = 400;
+
     @Description("올바른 이름 요청 시 지하철 역이 정상적으로 생성되어야 한다.")
     @Test
     public void 지하철_역_생성_테스트() {
@@ -169,12 +170,44 @@ public class SubwayTest extends AcceptanceTest {
         Long 서초역_아이디 = 2L;
 
         CreateLineRequest 이호선_데이터 = 지하철_노선_생성_데이터("짧음", "green", 10, 강남역_아이디, 서초역_아이디);
-        지하철_노선_생성하기(이호선_데이터);
 
         // when 동일한 이름의 노선으로 생성 요청을 보내면
         ExtractableResponse<Response> extract = 지하철_노선_생성하기(이호선_데이터);
         // then 거절되어야 한다.
         extract.response().then().log().all()
                 .assertThat().statusCode(INVALID_INPUT_STATUS_CODE);
+    }
+
+    @Description("올바른 요청으로 노선을 조회한 경우, 노선 정보가 올바르게 조회되어야 한다.")
+    @Test
+    public void 지하철_노선_조회_테스트() {
+        // given 2 개의 지하철 역으로 이루어진 하나의 노선을 생성하고
+        CreateStationRequest 강남역_데이터 = 지하철_역_생성_데이터("강남역");
+        지하철_역_생성하기(강남역_데이터);
+        Long 강남역_아이디 = 1L;
+
+        CreateStationRequest 서초역_데이터 = 지하철_역_생성_데이터("서초역");
+        지하철_역_생성하기(서초역_데이터);
+        Long 서초역_아이디 = 2L;
+
+        CreateLineRequest 이호선_데이터 = 지하철_노선_생성_데이터("짧음", "green", 10, 강남역_아이디, 서초역_아이디);
+        지하철_노선_생성하기(이호선_데이터);
+        // when 해당 지하철 노선을 조회하면
+        Long 이호선_아이디 = 1L;
+        ExtractableResponse<Response> extract = 지하철_노선_조회하기(이호선_아이디);
+        // then 잘 조회되어야 한다.
+        extract.response().then().log().all()
+                .assertThat().statusCode(HttpStatus.OK.value());
+    }
+
+    @Description("존재하지 않는 노선을 조회하려고 하는 경우, 거절되어야 한다.")
+    @Test
+    public void 존재하지_않는_지하철_노선_조회_테스트() {
+        // given & when 존재하지 않는 노선을 조회하려 하면
+        Long 노선_아이디 = 1L;
+        ExtractableResponse<Response> extract = 지하철_노선_조회하기(노선_아이디);
+        // then 거절되어야 한다.
+        extract.response().then().log().all()
+                .assertThat().statusCode(HttpStatus.BAD_REQUEST.value());
     }
 }

--- a/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
+++ b/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
@@ -23,7 +23,7 @@ public class SubwayTest extends AcceptanceTest {
     @Test
     public void 지하철_역_생성_테스트() {
         // given
-        CreateStationRequest 강남역_데이터 = 지하철_역_생성_데이터("강남역");
+        CreateStationRequest 강남역_데이터 = 지하철_역_생성_데이터_만들기("강남역");
         // when
         ExtractableResponse<Response> extract = 지하철_역_생성하기(강남역_데이터);
         // then
@@ -34,8 +34,8 @@ public class SubwayTest extends AcceptanceTest {
     @Test
     public void 지하철_목록_조회_테스트() {
         // given Given 2개의 지하철역을 생성하고
-        CreateStationRequest 강남역_데이터 = 지하철_역_생성_데이터("강남역");
-        CreateStationRequest 서초역_데이터 = 지하철_역_생성_데이터("서초역");
+        CreateStationRequest 강남역_데이터 = 지하철_역_생성_데이터_만들기("강남역");
+        CreateStationRequest 서초역_데이터 = 지하철_역_생성_데이터_만들기("서초역");
 
         지하철_역_생성하기(강남역_데이터);
         지하철_역_생성하기(서초역_데이터);
@@ -52,7 +52,7 @@ public class SubwayTest extends AcceptanceTest {
     @Test
     public void 지하철_삭제_테스트() {
         // given 지하철 역을 생성하고
-        CreateStationRequest 강남역_데이터 = 지하철_역_생성_데이터("강남역");
+        CreateStationRequest 강남역_데이터 = 지하철_역_생성_데이터_만들기("강남역");
         지하철_역_생성하기(강남역_데이터);
         // when 그 지하철 역을 삭제하면
         Long 강남역_아이디 = 1L;
@@ -69,8 +69,8 @@ public class SubwayTest extends AcceptanceTest {
     @Test
     public void 올바르지_않은_이름으로_지하철_역_생성_테스트() {
         // given 최소 길이보다 짧거나 최대 길이보다 긴 이름의 지하철 역 데이터로
-        CreateStationRequest 최소길이보다_짧은_이름의_지하철역 = 지하철_역_생성_데이터("강역");
-        CreateStationRequest 최대길이보다_긴_이름의_지하철역 = 지하철_역_생성_데이터("123456789.123456789.123456789");
+        CreateStationRequest 최소길이보다_짧은_이름의_지하철역 = 지하철_역_생성_데이터_만들기("강역");
+        CreateStationRequest 최대길이보다_긴_이름의_지하철역 = 지하철_역_생성_데이터_만들기("123456789.123456789.123456789");
         // when 지하철 역 생성 요청 시
         ExtractableResponse<Response> extract1 = 지하철_역_생성하기(최소길이보다_짧은_이름의_지하철역);
         ExtractableResponse<Response> extract2 = 지하철_역_생성하기(최대길이보다_긴_이름의_지하철역);
@@ -86,7 +86,7 @@ public class SubwayTest extends AcceptanceTest {
     @Test
     public void 이미존재하는_이름으로_지하철역_생성_테스트() {
         // given "강남역" 지하철역이 이미 존재할 때
-        CreateStationRequest 강남역_데이터 = 지하철_역_생성_데이터("강남역");
+        CreateStationRequest 강남역_데이터 = 지하철_역_생성_데이터_만들기("강남역");
         지하철_역_생성하기(강남역_데이터);
         // when "강남역" 이름으로 지하철 역을 생성하려고 하면
         ExtractableResponse<Response> extract = 지하철_역_생성하기(강남역_데이터);
@@ -100,15 +100,11 @@ public class SubwayTest extends AcceptanceTest {
     @Test
     public void 지하철_노선_생성_테스트() {
         // given 2개의 지하철 역을 생성하고
-        CreateStationRequest 강남역_데이터 = 지하철_역_생성_데이터("강남역");
-        지하철_역_생성하기(강남역_데이터);
+        강남역_서초역_더미데이터_생성하기();
         Long 강남역_아이디 = 1L;
-
-        CreateStationRequest 서초역_데이터 = 지하철_역_생성_데이터("서초역");
-        지하철_역_생성하기(서초역_데이터);
         Long 서초역_아이디 = 2L;
         // when 새로운 노선에 상행 종점역과 하행 종점역으로 요청을 보내면
-        CreateLineRequest 이호선_데이터 = 지하철_노선_생성_데이터("2호선", "green", 10, 강남역_아이디, 서초역_아이디);
+        CreateLineRequest 이호선_데이터 = 지하철_노선_생성_데이터_만들기("2호선", "green", 10, 강남역_아이디, 서초역_아이디);
         ExtractableResponse<Response> extract = 지하철_노선_생성하기(이호선_데이터);
 
         // then 생성된 노선의 Id 를 응답으로 받는다.
@@ -121,15 +117,10 @@ public class SubwayTest extends AcceptanceTest {
     @Test
     public void 동일_역에_대한_지하철_노선_생성_테스트() {
         // given 2개의 지하철 역을 생성하고
-        CreateStationRequest 강남역_데이터 = 지하철_역_생성_데이터("강남역");
-        지하철_역_생성하기(강남역_데이터);
+        강남역_서초역_더미데이터_생성하기();
         Long 강남역_아이디 = 1L;
-
-        CreateStationRequest 서초역_데이터 = 지하철_역_생성_데이터("서초역");
-        지하철_역_생성하기(서초역_데이터);
-        Long 서초역_아이디 = 1L;
         // when 상행 종점역과 하행 종점역을 같은 역으로 노선 생성 요청을 보내면
-        CreateLineRequest 이호선_데이터 = 지하철_노선_생성_데이터("2호선", "green", 10, 강남역_아이디, 서초역_아이디);
+        CreateLineRequest 이호선_데이터 = 지하철_노선_생성_데이터_만들기("2호선", "green", 10, 강남역_아이디, 강남역_아이디);
         ExtractableResponse<Response> extract = 지하철_노선_생성하기(이호선_데이터);
 
         // then 거절되어야 한다.
@@ -141,15 +132,11 @@ public class SubwayTest extends AcceptanceTest {
     @Test
     public void 중복된_지하철_노선_생성_테스트() {
         // given 2개의 지하철 역을 생성하고 하나의 노선을 만든다.
-        CreateStationRequest 강남역_데이터 = 지하철_역_생성_데이터("강남역");
-        지하철_역_생성하기(강남역_데이터);
+        강남역_서초역_더미데이터_생성하기();
         Long 강남역_아이디 = 1L;
-
-        CreateStationRequest 서초역_데이터 = 지하철_역_생성_데이터("서초역");
-        지하철_역_생성하기(서초역_데이터);
         Long 서초역_아이디 = 2L;
 
-        CreateLineRequest 이호선_데이터 = 지하철_노선_생성_데이터("2호선", "green", 10, 강남역_아이디, 서초역_아이디);
+        CreateLineRequest 이호선_데이터 = 지하철_노선_생성_데이터_만들기("2호선", "green", 10, 강남역_아이디, 서초역_아이디);
         지하철_노선_생성하기(이호선_데이터);
 
         // when 동일한 이름의 노선으로 생성 요청을 보내면
@@ -163,15 +150,11 @@ public class SubwayTest extends AcceptanceTest {
     @Test
     public void 올바르지않은_이름으로_지하철_노선_생성_테스트() {
         // given 2개의 지하철 역을 생성하고 하나의 노선을 만든다.
-        CreateStationRequest 강남역_데이터 = 지하철_역_생성_데이터("강남역");
-        지하철_역_생성하기(강남역_데이터);
+        강남역_서초역_더미데이터_생성하기();
         Long 강남역_아이디 = 1L;
-
-        CreateStationRequest 서초역_데이터 = 지하철_역_생성_데이터("서초역");
-        지하철_역_생성하기(서초역_데이터);
         Long 서초역_아이디 = 2L;
 
-        CreateLineRequest 이호선_데이터 = 지하철_노선_생성_데이터("짧음", "green", 10, 강남역_아이디, 서초역_아이디);
+        CreateLineRequest 이호선_데이터 = 지하철_노선_생성_데이터_만들기("짧음", "green", 10, 강남역_아이디, 서초역_아이디);
 
         // when 동일한 이름의 노선으로 생성 요청을 보내면
         ExtractableResponse<Response> extract = 지하철_노선_생성하기(이호선_데이터);
@@ -184,15 +167,11 @@ public class SubwayTest extends AcceptanceTest {
     @Test
     public void 지하철_노선_조회_테스트() {
         // given 2 개의 지하철 역으로 이루어진 하나의 노선을 생성하고
-        CreateStationRequest 강남역_데이터 = 지하철_역_생성_데이터("강남역");
-        지하철_역_생성하기(강남역_데이터);
+        강남역_서초역_더미데이터_생성하기();
         Long 강남역_아이디 = 1L;
-
-        CreateStationRequest 서초역_데이터 = 지하철_역_생성_데이터("서초역");
-        지하철_역_생성하기(서초역_데이터);
         Long 서초역_아이디 = 2L;
 
-        CreateLineRequest 이호선_데이터 = 지하철_노선_생성_데이터("이호선", "green", 10, 강남역_아이디, 서초역_아이디);
+        CreateLineRequest 이호선_데이터 = 지하철_노선_생성_데이터_만들기("이호선", "green", 10, 강남역_아이디, 서초역_아이디);
         지하철_노선_생성하기(이호선_데이터);
         // when 해당 지하철 노선을 조회하면
         Long 이호선_아이디 = 1L;
@@ -206,8 +185,7 @@ public class SubwayTest extends AcceptanceTest {
     @Test
     public void 존재하지_않는_지하철_노선_조회_테스트() {
         // given & when 존재하지 않는 노선을 조회하려 하면
-        Long 노선_아이디 = 1L;
-        ExtractableResponse<Response> extract = 지하철_노선_조회하기(노선_아이디);
+        ExtractableResponse<Response> extract = 지하철_노선_조회하기(1L);
         // then 거절되어야 한다.
         extract.response().then().log().all()
                 .assertThat().statusCode(HttpStatus.NOT_FOUND.value());
@@ -217,26 +195,22 @@ public class SubwayTest extends AcceptanceTest {
     @Test
     public void 지하철_노선_수정_테스트() {
         // given 2 개의 지하철 역으로 이루어진 하나의 노선을 생성하고
-        CreateStationRequest 강남역_데이터 = 지하철_역_생성_데이터("강남역");
-        지하철_역_생성하기(강남역_데이터);
+        강남역_서초역_더미데이터_생성하기();
         Long 강남역_아이디 = 1L;
-
-        CreateStationRequest 서초역_데이터 = 지하철_역_생성_데이터("서초역");
-        지하철_역_생성하기(서초역_데이터);
         Long 서초역_아이디 = 2L;
 
-        CreateLineRequest 이호선_데이터 = 지하철_노선_생성_데이터("이호선", "green", 10, 강남역_아이디, 서초역_아이디);
+        CreateLineRequest 이호선_데이터 = 지하철_노선_생성_데이터_만들기("이호선", "green", 10, 강남역_아이디, 서초역_아이디);
         지하철_노선_생성하기(이호선_데이터);
         // when 해당 지하철 노선을 수정하려고 요청하면
-        CreateStationRequest 어린이대공원역_데이터 = 지하철_역_생성_데이터("어린이대공원역");
+        CreateStationRequest 어린이대공원역_데이터 = 지하철_역_생성_데이터_만들기("어린이대공원역");
         지하철_역_생성하기(어린이대공원역_데이터);
         Long 어린이대공원역_아이디 = 3L;
 
-        CreateStationRequest 건대입구역_데이터 = 지하철_역_생성_데이터("건대입구역");
+        CreateStationRequest 건대입구역_데이터 = 지하철_역_생성_데이터_만들기("건대입구역");
         지하철_역_생성하기(건대입구역_데이터);
         Long 건대입구역_아이디 = 4L;
 
-        ModifyLineRequest 노선_수정_데이터 = 지하철_노선_수정_데이터("경춘선", "red", 99, 어린이대공원역_아이디, 건대입구역_아이디);
+        ModifyLineRequest 노선_수정_데이터 = 지하철_노선_수정_데이터_만들기("경춘선", "red", 99, 어린이대공원역_아이디, 건대입구역_아이디);
         ExtractableResponse<Response> extract = 지하철_노선_수정하기(노선_수정_데이터, 1L);
 
         // 수정되어야 한다.
@@ -248,20 +222,8 @@ public class SubwayTest extends AcceptanceTest {
     @Description("존재하지 않는 노선을 수정 요청한 경우, 거절되어야 한다.")
     @Test
     public void 존재하지_않는_지하철_노선_수정_테스트() {
-        // given 2 개의 지하철 역으로 이루어진 하나의 노선을 생성하고
-        CreateStationRequest 강남역_데이터 = 지하철_역_생성_데이터("강남역");
-        지하철_역_생성하기(강남역_데이터);
-        Long 강남역_아이디 = 1L;
-
-        CreateStationRequest 서초역_데이터 = 지하철_역_생성_데이터("서초역");
-        지하철_역_생성하기(서초역_데이터);
-        Long 서초역_아이디 = 2L;
-
-        CreateLineRequest 이호선_데이터 = 지하철_노선_생성_데이터("이호선", "green", 10, 강남역_아이디, 서초역_아이디);
-        지하철_노선_생성하기(이호선_데이터);
-        // when 존재하지 않는 다른 노선을 수정하려고 요청하면
-
-        ModifyLineRequest 노선_수정_데이터 = 지하철_노선_수정_데이터("경춘선", "red", 99, 강남역_아이디, 서초역_아이디);
+        // when & given 존재하지 않는 다른 노선을 수정하려고 요청하면
+        ModifyLineRequest 노선_수정_데이터 = 지하철_노선_수정_데이터_만들기("경춘선", "red", 99, 1L, 2L);
         ExtractableResponse<Response> extract = 지하철_노선_수정하기(노선_수정_데이터, 99L);
 
         // 거절되어야 한다.
@@ -273,15 +235,11 @@ public class SubwayTest extends AcceptanceTest {
     @Test
     public void 지하철_노선_삭제_테스트() {
         // given 2 개의 지하철 역으로 이루어진 하나의 노선을 생성하고
-        CreateStationRequest 강남역_데이터 = 지하철_역_생성_데이터("강남역");
-        지하철_역_생성하기(강남역_데이터);
+        강남역_서초역_더미데이터_생성하기();
         Long 강남역_아이디 = 1L;
-
-        CreateStationRequest 서초역_데이터 = 지하철_역_생성_데이터("서초역");
-        지하철_역_생성하기(서초역_데이터);
         Long 서초역_아이디 = 2L;
 
-        CreateLineRequest 이호선_데이터 = 지하철_노선_생성_데이터("이호선", "green", 10, 강남역_아이디, 서초역_아이디);
+        CreateLineRequest 이호선_데이터 = 지하철_노선_생성_데이터_만들기("이호선", "green", 10, 강남역_아이디, 서초역_아이디);
         지하철_노선_생성하기(이호선_데이터);
         // when 해당 노선을 삭제 요청 시
         Long 이호선_아이디 = 1L;
@@ -298,21 +256,10 @@ public class SubwayTest extends AcceptanceTest {
     @Description("존재하지 않는 노선을 삭제 요청한 경우, 거절되어야 한다.")
     @Test
     public void 존재하지_않는_지하철_노선_삭제_테스트() {
-        // given 2 개의 지하철 역으로 이루어진 하나의 노선을 생성하고
-        CreateStationRequest 강남역_데이터 = 지하철_역_생성_데이터("강남역");
-        지하철_역_생성하기(강남역_데이터);
-        Long 강남역_아이디 = 1L;
-
-        CreateStationRequest 서초역_데이터 = 지하철_역_생성_데이터("서초역");
-        지하철_역_생성하기(서초역_데이터);
-        Long 서초역_아이디 = 2L;
-
-        CreateLineRequest 이호선_데이터 = 지하철_노선_생성_데이터("이호선", "green", 10, 강남역_아이디, 서초역_아이디);
-        지하철_노선_생성하기(이호선_데이터);
-        // when 존재하지 않는 지하철 노선을 삭제 요청 시
-        ExtractableResponse<Response> extract1 = 지하철_노선_삭제하기(99L);
+        // when & given 존재하지 않는 지하철 노선을 삭제 요청 시
+        ExtractableResponse<Response> extract = 지하철_노선_삭제하기(99L);
         // then 거절되어야 한다.
-        extract1.response().then().log().all()
+        extract.response().then().log().all()
                 .assertThat().statusCode(HttpStatus.NOT_FOUND.value());
     }
 }

--- a/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
+++ b/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
@@ -26,7 +26,7 @@ public class SubwayTest extends AcceptanceTest {
         Assertions.assertEquals(HttpStatus.OK.value(), extract.statusCode());
     }
 
-    @Description("지하철 목록 조회 API 인수 테스트")
+    @Description("생성된 지하철 역 목록이 올바르게 조회되어야 한다.")
     @Test
     public void 지하철_목록_조회() {
         // given Given 2개의 지하철역을 생성하고
@@ -44,7 +44,7 @@ public class SubwayTest extends AcceptanceTest {
                 .assertThat().statusCode(HttpStatus.OK.value());
     }
 
-    @Description("지하철 삭제 API 인수 테스트")
+    @Description("생성된 지하철 역에 대한 삭제 요청 시, 해당 지하철 역은 목록에서 제거되어야 한다.")
     @Test
     public void 지하철_삭제() {
         // given 지하철 역을 생성하고

--- a/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
+++ b/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
@@ -62,12 +62,12 @@ public class SubwayTest extends AcceptanceTest {
         RestAssured.given().log().all()
                 .when().delete(PATH + "/{id}", String.valueOf(station.getId()))
                 .then().log().all()
-                .assertThat().statusCode(HttpStatus.OK.value());
+                .assertThat().statusCode(HttpStatus.NO_CONTENT.value());
 
         // then 그 지하철 역 목록 조회 시 생성한 역을 찾을 수 없다.
         RestAssured.given().log().all()
                 .when().get(PATH)
                 .then().log().all()
-                .assertThat().statusCode(HttpStatus.NO_CONTENT.value());
+                .assertThat().statusCode(HttpStatus.OK.value());
     }
 }

--- a/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
+++ b/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
@@ -56,10 +56,12 @@ public class SubwayTest extends AcceptanceTest {
         지하철_역_생성하기(강남역_데이터);
         // when 그 지하철 역을 삭제하면
         Long 강남역_아이디 = 1L;
-        지하철_역_삭제하기(강남역_아이디);
+        ExtractableResponse<Response> extract1 = 지하철_역_삭제하기(강남역_아이디);
+        extract1.response().then().log().all()
+                .assertThat().statusCode(HttpStatus.NO_CONTENT.value());
         // then 그 지하철 역 목록 조회 시 생성한 역을 찾을 수 없다.
-        ExtractableResponse<Response> extract = 지하철_역_목록_조회하기();
-        int 응답_코드 = extract.statusCode();
+        ExtractableResponse<Response> extract2 = 지하철_역_목록_조회하기();
+        int 응답_코드 = extract2.statusCode();
         Assertions.assertEquals(HttpStatus.OK.value(), 응답_코드);
     }
 
@@ -264,6 +266,53 @@ public class SubwayTest extends AcceptanceTest {
 
         // 거절되어야 한다.
         extract.response().then().log().all()
+                .assertThat().statusCode(HttpStatus.NOT_FOUND.value());
+    }
+
+    @Description("존재하는 노선을 삭제 요청한 경우, 삭제되어야 한다.")
+    @Test
+    public void 지하철_노선_삭제_테스트() {
+        // given 2 개의 지하철 역으로 이루어진 하나의 노선을 생성하고
+        CreateStationRequest 강남역_데이터 = 지하철_역_생성_데이터("강남역");
+        지하철_역_생성하기(강남역_데이터);
+        Long 강남역_아이디 = 1L;
+
+        CreateStationRequest 서초역_데이터 = 지하철_역_생성_데이터("서초역");
+        지하철_역_생성하기(서초역_데이터);
+        Long 서초역_아이디 = 2L;
+
+        CreateLineRequest 이호선_데이터 = 지하철_노선_생성_데이터("이호선", "green", 10, 강남역_아이디, 서초역_아이디);
+        지하철_노선_생성하기(이호선_데이터);
+        // when 해당 노선을 삭제 요청 시
+        Long 이호선_아이디 = 1L;
+        ExtractableResponse<Response> extract1 = 지하철_노선_삭제하기(이호선_아이디);
+        // then 삭제 되어야 하고, 해당 노선 정보 조회 요청은 거절되어야 한다.
+        extract1.response().then().log().all()
+                .assertThat().statusCode(HttpStatus.NO_CONTENT.value());
+
+        ExtractableResponse<Response> extract2 = 지하철_노선_조회하기(이호선_아이디);
+        extract2.response().then().log().all()
+                .assertThat().statusCode(HttpStatus.NOT_FOUND.value());
+    }
+
+    @Description("존재하지 않는 노선을 삭제 요청한 경우, 거절되어야 한다.")
+    @Test
+    public void 존재하지_않는_지하철_노선_삭제_테스트() {
+        // given 2 개의 지하철 역으로 이루어진 하나의 노선을 생성하고
+        CreateStationRequest 강남역_데이터 = 지하철_역_생성_데이터("강남역");
+        지하철_역_생성하기(강남역_데이터);
+        Long 강남역_아이디 = 1L;
+
+        CreateStationRequest 서초역_데이터 = 지하철_역_생성_데이터("서초역");
+        지하철_역_생성하기(서초역_데이터);
+        Long 서초역_아이디 = 2L;
+
+        CreateLineRequest 이호선_데이터 = 지하철_노선_생성_데이터("이호선", "green", 10, 강남역_아이디, 서초역_아이디);
+        지하철_노선_생성하기(이호선_데이터);
+        // when 존재하지 않는 지하철 노선을 삭제 요청 시
+        ExtractableResponse<Response> extract1 = 지하철_노선_삭제하기(99L);
+        // then 거절되어야 한다.
+        extract1.response().then().log().all()
                 .assertThat().statusCode(HttpStatus.NOT_FOUND.value());
     }
 }

--- a/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
+++ b/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
@@ -190,7 +190,7 @@ public class SubwayTest extends AcceptanceTest {
         지하철_역_생성하기(서초역_데이터);
         Long 서초역_아이디 = 2L;
 
-        CreateLineRequest 이호선_데이터 = 지하철_노선_생성_데이터("짧음", "green", 10, 강남역_아이디, 서초역_아이디);
+        CreateLineRequest 이호선_데이터 = 지하철_노선_생성_데이터("이호선", "green", 10, 강남역_아이디, 서초역_아이디);
         지하철_노선_생성하기(이호선_데이터);
         // when 해당 지하철 노선을 조회하면
         Long 이호선_아이디 = 1L;

--- a/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
+++ b/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
@@ -75,4 +75,19 @@ public class SubwayTest extends AcceptanceTest {
                 .assertThat().statusCode(400);
         지하철_역_목록_조회하기();
     }
+
+    @Description("이미 존재하는 이름으로 지하철 역 생성 요청 시, 거절되어야 한다.")
+    @Test
+    public void 이미존재하는_이름으로_지하철역_생성 () {
+        // given "강남역" 지하철역이 이미 존재할 때
+        CreateStationRequest 강남역_데이터 = 지하철_역_생성_데이터("강남역");
+        지하철_역_생성하기(강남역_데이터);
+        // when "강남역" 이름으로 지하철 역을 생성하려고 하면
+        ExtractableResponse<Response> extract = 지하철_역_생성하기(강남역_데이터);
+        // then 거절되어야 하고, 지하철 역 목록에 반영되면 안된다.
+        extract.response().then().log().all()
+                .assertThat().statusCode(400);
+        지하철_역_목록_조회하기();
+    }
+
 }

--- a/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
+++ b/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
@@ -1,0 +1,28 @@
+package kuit.subway.study.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import kuit.subway.AcceptanceTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SubwayTest extends AcceptanceTest {
+    @Test
+    public void 지하철_역_생성() {
+        // given
+        Map<String, String> body = new HashMap<>();
+        body.put("name", "강남역");
+        // when
+        ExtractableResponse<Response> extract = RestAssured.given().log().all()
+                .body(body)
+                .when().post("stations")
+                .then().log().all()
+                .extract();
+        // then
+        Assertions.assertEquals(200, extract.statusCode());
+    }
+}

--- a/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
+++ b/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
@@ -6,10 +6,12 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import kuit.subway.AcceptanceTest;
 import kuit.subway.dto.request.CreateStationRequest;
+import kuit.subway.dto.response.CreateStationResponse;
 import kuit.subway.service.StationService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -49,9 +51,18 @@ public class SubwayTest extends AcceptanceTest {
     @Test
     public void 지하철_삭제() throws Exception {
         // given 지하철 역을 생성하고
-        stationService.createOne("강남역");
+        CreateStationResponse station = stationService.createOne("강남역");
 
         // when 그 지하철 역을 삭제하면
+        RestAssured.given().log().all()
+                .when().delete("/stations/{id}", String.valueOf(station.getId()))
+                .then().log().all()
+                .assertThat().statusCode(HttpStatus.OK.value());
+
         // then 그 지하철 역 목록 조회 시 생성한 역을 찾을 수 없다.
+        RestAssured.given().log().all()
+                .when().get("/stations")
+                .then().log().all()
+                .assertThat().statusCode(HttpStatus.NO_CONTENT.value());
     }
 }

--- a/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
+++ b/src/test/java/kuit/subway/study/acceptance/SubwayTest.java
@@ -89,5 +89,13 @@ public class SubwayTest extends AcceptanceTest {
                 .assertThat().statusCode(400);
         지하철_역_목록_조회하기();
     }
+    @Description("지하철 노선 요청이 올바르면, 노선이 생성되어야 한다.")
+    @Test
+    public void 지하철_노선_생성_테스트 (){
+        // given 2개의 지하철 역을 생성하고
 
+        // when 새로운 노선에 상행 종점역과 하행 종점역으로 요청을 보내면
+
+        // then 생성된 노선의 Id 를 응답으로 받는다.
+    }
 }


### PR DESCRIPTION
### 지하철 노선(Line) 도메인 구현
- Station 과의 연관관계 설정을 고민하다가... step 2 구현 요구사항까지는 필요하지 않을 것 같아서 적용하지 않음
  - Station 과 Line 은 역시 다대다 이려나요? 추후에 도입될 구간(Section) 까지 고려해서 연관관계를 어떻게 설정해야 할 지 고민중입니다.. 😥😥
-  Line 엔티티 생성자에 validate 로직을 넣음으로써 Line 이름이 중복되는 경우를 막고자 했습니다.
```
    @Builder
    public Line(String name, int distance, Long downStationId, Long upStationId, String color) {
        validateStations(downStationId, upStationId);
        this.name = name;
        this.distance = distance;
        this.downStationId = downStationId;
        this.upStationId = upStationId;
        this.color = color;
    }

    public void validateStations(Long downStationId, Long upStationId) {
        if (downStationId == upStationId) {
            throw new InvalidCreateLineException();
        }
    }
``` 
- 이밖의 특이사항은,, 반드시 필요한 필드에 대해서만 setter 을 구현하여, Service 계층에서 트랜잭션 단위로 더티체킹되어 DB 에 반영되도록 하였습니다.

---

### 도메인 생성 시간, 수정 시간 관리
- BaseTimeEntity 를 구현한 뒤 Jpa Auditing 기능을 이용하여, BaseTimeEntity 를 상속받은 엔티티들이 생성 시간, 수정 시간 필드를 가지도록 구현하였습니다.


### LineService 
- 노선 관련 비지니스 로직을 구현합니다.

---

### 궁금한점 1.
LineService 를 구현하다가, StationRepository 에 접근해야 할 상황이 종종 생겼습니다.
- StationRepository 의 의존성을 주입받는 것은 오직 StationService 이여야 controller - service - repository 구조가 깔끔하게 지켜질 것 같아서,  LineService 에서는 StationRepository 가 아닌 StationService 의 의존성을 주입받도록 하였습니다. 이러한,, 사소한 의사결정 과정이 자연스러운지..? 궁금합니다
```
@RequiredArgsConstructor
@Transactional(readOnly = true)
@Service
public class LineService {
    // private final StationRepository stationRepository; // 대신에
    private final StationService stationService; // service 를!
    private final LineRepository lineRepository;

```

### 궁금한점 2.
최대한 많은 경우에 대해서 인수 테스트를 작성하기 위해 노력하고 있습니다.
그러다 보니 accentance/SubwayTest 클래스의 코드양이 너무 많아지는 것 같은데,, 역시 클래스를 분리하는 게 좋을까요 ?? 
- 가령 예외처리에 대한 인수테스트 클래스를 따로 둔다던지.. 혹은 도메인 별 인수테스트 클래스를 따로 둔다던다..

아니면 제가 작성한 SubwayTest 에서 너무 불필요하게 중복된 코드가 많이 남아있는걸까요..??
리팩토링하며 중복을 줄이려고 노력했는데 여전히 많은 것 같아서 이렇게 코멘트 남깁니다!!

감사합니다 : )

