### PR TITLE
[1차 과제 - Step3] 이상진

### DIFF
--- a/src/main/java/kuit/subway/global/exception/CustomExceptionStatus.java
+++ b/src/main/java/kuit/subway/global/exception/CustomExceptionStatus.java
@@ -21,6 +21,11 @@ public enum CustomExceptionStatus implements ExceptionStatus {
     // line exception
     NOT_EXISTED_LINE(HttpStatus.BAD_REQUEST, "존재하지 않는 노선입니다."),
     DUPLICATED_UP_STATION_AND_DOWN_STATION(HttpStatus.BAD_REQUEST, "상행종점역과 하행종점역이 중복됩니다."),
+
+    // section exception
+    INVALID_SECTION_NOT_EXISTED_DOWN_STATION(HttpStatus.BAD_REQUEST, "새로운 구간의 상행역은 해당 노선에 등록되어있는 하행 종점역이여야 합니다."),
+    INVALID_SECTION_CANNOT_CYCLE(HttpStatus.BAD_REQUEST, "새로운 구간의 하행역은 해당 노선에 등록되어있을 수 없습니다."),
+    CANNOT_REMOVE_SECTION(HttpStatus.BAD_REQUEST, "상행 종점역과 하행 종점역만 있는 경우, 구간을 삭제할 수 없습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kuit/subway/line/controller/LineController.java
+++ b/src/main/java/kuit/subway/line/controller/LineController.java
@@ -60,4 +60,10 @@ public class LineController {
         return ResponseEntity.created(URI.create("/line/" + response.getId() + "/sections"))
                 .body(response);
     }
+
+    @DeleteMapping("/{lineId}/sections")
+    public ResponseEntity<LineResponse> deleteSection(@PathVariable Long lineId) {
+        LineResponse response = lineService.deleteSection(lineId);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/kuit/subway/line/controller/LineController.java
+++ b/src/main/java/kuit/subway/line/controller/LineController.java
@@ -55,7 +55,7 @@ public class LineController {
 
     @PostMapping("/{lineId}/sections")
     public ResponseEntity<LineResponse> createSection(@PathVariable Long lineId,
-                                                   @Valid @RequestBody SectionRequest request) {
+                                                      @Valid @RequestBody SectionRequest request) {
         LineResponse response = lineService.createSection(lineId, request);
         return ResponseEntity.created(URI.create("/line/" + response.getId() + "/sections"))
                 .body(response);

--- a/src/main/java/kuit/subway/line/controller/LineController.java
+++ b/src/main/java/kuit/subway/line/controller/LineController.java
@@ -2,6 +2,7 @@ package kuit.subway.line.controller;
 
 import jakarta.validation.Valid;
 import kuit.subway.line.dto.request.LineRequest;
+import kuit.subway.line.dto.request.SectionRequest;
 import kuit.subway.line.dto.response.LineCreateResponse;
 import kuit.subway.line.dto.response.LineResponse;
 import kuit.subway.line.service.LineService;
@@ -50,5 +51,13 @@ public class LineController {
     public ResponseEntity<Void> deleteLine(@PathVariable Long lineId) {
         lineService.deleteLine(lineId);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{lineId}/sections")
+    public ResponseEntity<LineResponse> createSection(@PathVariable Long lineId,
+                                                   @Valid @RequestBody SectionRequest request) {
+        LineResponse response = lineService.createSection(lineId, request);
+        return ResponseEntity.created(URI.create("/line/" + response.getId() + "/sections"))
+                .body(response);
     }
 }

--- a/src/main/java/kuit/subway/line/domain/Line.java
+++ b/src/main/java/kuit/subway/line/domain/Line.java
@@ -26,6 +26,7 @@ public class Line extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "line_id")
     private Long id;
 
     @Column(length = 10, nullable = false)

--- a/src/main/java/kuit/subway/line/domain/Line.java
+++ b/src/main/java/kuit/subway/line/domain/Line.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import kuit.subway.BaseTimeEntity;
 import kuit.subway.global.exception.SubwayException;
+import kuit.subway.station.domain.Station;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,8 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.ArrayList;
 import java.util.List;
 
-import static kuit.subway.global.exception.CustomExceptionStatus.INVALID_SECTION_CANNOT_CYCLE;
-import static kuit.subway.global.exception.CustomExceptionStatus.INVALID_SECTION_NOT_EXISTED_DOWN_STATION;
+import static kuit.subway.global.exception.CustomExceptionStatus.*;
 
 @Entity
 @Getter
@@ -57,6 +57,22 @@ public class Line extends BaseTimeEntity {
     public void addSection(Section section) {
         validateAvailableSection(section);
         this.sections.add(section);
+    }
+
+    // TODO 리팩토링 필수
+    public List<Station> getStations() {
+        List<Station> stations = new ArrayList<>();
+        boolean isFirst = true;
+        for (Section section : sections) {
+            if (isFirst) {
+                stations.add(section.getUpStation());
+                stations.add(section.getDownStation());
+            } else {
+                stations.add(section.getDownStation());
+            }
+            isFirst = false;
+        }
+        return stations;
     }
 
     private void validateAvailableSection(Section section) {

--- a/src/main/java/kuit/subway/line/domain/Line.java
+++ b/src/main/java/kuit/subway/line/domain/Line.java
@@ -8,12 +8,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import kuit.subway.BaseTimeEntity;
-import kuit.subway.station.domain.Station;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,6 +22,7 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Slf4j
 public class Line extends BaseTimeEntity {
 
     @Id
@@ -35,35 +36,17 @@ public class Line extends BaseTimeEntity {
     @Column(length = 10, nullable = false)
     private String color;
 
-    private Long distance;
-
-    @OneToMany(mappedBy = "line", cascade = CascadeType.REMOVE, orphanRemoval = true)
-    public List<Station> stations = new ArrayList<>();
+    @OneToMany(mappedBy = "line", cascade = CascadeType.ALL, orphanRemoval = true)
+    public List<Section> sections = new ArrayList<>();
 
     @Builder
-    public Line(String name, String color, Long distance, List<Station> stations) {
+    public Line(String name, String color) {
         this.name = name;
         this.color = color;
-        this.distance = distance;
-        if (stations != null) {
-            this.stations = stations;
-            addStations(stations);
-        }
     }
 
-    private void addStations(List<Station> stations) {
-        stations.forEach(station -> station.addLine(this));
-    }
-
-    public void updateInfo(String name, String color, Long distance) {
+    public void update(String name, String color) {
         this.name = name;
         this.color = color;
-        this.distance = distance;
-    }
-
-    public void updateStations(List<Station> stations) {
-        this.stations.clear();
-        this.stations.addAll(stations);
-        addStations(stations);
     }
 }

--- a/src/main/java/kuit/subway/line/domain/Line.java
+++ b/src/main/java/kuit/subway/line/domain/Line.java
@@ -75,6 +75,13 @@ public class Line extends BaseTimeEntity {
         return stations;
     }
 
+    public void removeSection() {
+        if (sections.size() == 1) {
+            throw new SubwayException(CANNOT_REMOVE_SECTION);
+        }
+        sections.remove(sections.size() - 1);
+    }
+
     private void validateAvailableSection(Section section) {
         // 처음 역을 만드는 경우
         if (sections.size() == 0) {

--- a/src/main/java/kuit/subway/line/domain/Section.java
+++ b/src/main/java/kuit/subway/line/domain/Section.java
@@ -1,0 +1,53 @@
+package kuit.subway.line.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import kuit.subway.station.domain.Station;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Section {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "section_id")
+    private Long id;
+
+    private Long distance;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "line_id")
+    private Line line;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "up_station_id")
+    private Station upStation;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "down_station_id")
+    private Station downStation;
+
+    public static Section createSection(Long distance, Line line, Station upStation, Station downStation) {
+        return Section.builder()
+                .distance(distance)
+                .line(line)
+                .upStation(upStation)
+                .downStation(downStation)
+                .build();
+    }
+}
+

--- a/src/main/java/kuit/subway/line/dto/request/LineRequest.java
+++ b/src/main/java/kuit/subway/line/dto/request/LineRequest.java
@@ -4,14 +4,11 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import kuit.subway.line.domain.Line;
-import kuit.subway.station.domain.Station;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 @Builder
 @Getter
@@ -26,16 +23,13 @@ public class LineRequest {
     @NotNull
     @Min(1)
     private Long distance;
-
     private Long downStationId;
     private Long upStationId;
 
-    public Line toEntity(List<Station> stations) {
+    public Line toEntity() {
         return Line.builder()
                 .name(name)
                 .color(color)
-                .distance(distance)
-                .stations(stations)
                 .build();
     }
 }

--- a/src/main/java/kuit/subway/line/dto/request/SectionRequest.java
+++ b/src/main/java/kuit/subway/line/dto/request/SectionRequest.java
@@ -1,0 +1,22 @@
+package kuit.subway.line.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SectionRequest {
+
+    @NotNull
+    @Min(1)
+    private Long distance;
+    private Long downStationId;
+    private Long upStationId;
+}

--- a/src/main/java/kuit/subway/line/dto/response/LineResponse.java
+++ b/src/main/java/kuit/subway/line/dto/response/LineResponse.java
@@ -19,12 +19,12 @@ public class LineResponse {
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
 
-    public static LineResponse of(Line line, List<StationResponse> stations) {
+    public static LineResponse of(Line line) {
         return LineResponse.builder()
                 .id(line.getId())
                 .name(line.getName())
                 .color(line.getColor())
-                .stations(stations)
+                .stations(line.getStations().stream().map(StationResponse::of).toList())
                 .createdDate(line.getCreatedDate())
                 .modifiedDate(line.getModifiedDate())
                 .build();

--- a/src/main/java/kuit/subway/line/service/LineService.java
+++ b/src/main/java/kuit/subway/line/service/LineService.java
@@ -2,19 +2,17 @@ package kuit.subway.line.service;
 
 import kuit.subway.global.exception.SubwayException;
 import kuit.subway.line.domain.Line;
+import kuit.subway.line.domain.Section;
 import kuit.subway.line.dto.request.LineRequest;
 import kuit.subway.line.dto.response.LineCreateResponse;
 import kuit.subway.line.dto.response.LineResponse;
 import kuit.subway.line.repository.LineRepository;
 import kuit.subway.station.domain.Station;
-import kuit.subway.station.dto.response.StationResponse;
 import kuit.subway.station.repository.StationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 import static kuit.subway.global.exception.CustomExceptionStatus.*;
 
@@ -30,11 +28,17 @@ public class LineService {
     @Transactional
     public LineCreateResponse createLine(LineRequest request) {
         validateDuplicatedStations(request);
-        List<Station> stations = extractStationsFrom(request);
-
-        Line line = request.toEntity(stations);
-
+        Line line = request.toEntity();
         lineRepository.save(line);
+
+        Station upStation = stationRepository.findById(request.getUpStationId())
+                .orElseThrow(() -> new SubwayException(NOT_EXISTED_STATION));
+        Station downStation = stationRepository.findById(request.getDownStationId())
+                .orElseThrow(() -> new SubwayException(NOT_EXISTED_STATION));
+
+        Section section = Section.createSection(request.getDistance(), line, upStation, downStation);
+        line.addSection(section);
+
         return LineCreateResponse.of(line);
     }
 
@@ -42,11 +46,7 @@ public class LineService {
         Line line = lineRepository.findById(lineId)
                 .orElseThrow(() -> new SubwayException(NOT_EXISTED_LINE));
 
-        List<StationResponse> stationResponses = line.getStations().stream()
-                .map(StationResponse::of)
-                .toList();
-
-        return LineResponse.of(line, stationResponses);
+        return LineResponse.of(line);
     }
 
     @Transactional
@@ -54,15 +54,9 @@ public class LineService {
         Line line = lineRepository.findById(lineId)
                 .orElseThrow(() -> new SubwayException(NOT_EXISTED_LINE));
 
-        validateDuplicatedStations(request);
-        List<Station> stations = extractStationsFrom(request);
+        line.update(request.getName(), request.getColor());
 
-        line.updateInfo(request.getName(), request.getColor(), request.getDistance());
-        line.updateStations(stations);
-
-        List<StationResponse> stationResponses = stations.stream().map(StationResponse::of).toList();
-
-        return LineResponse.of(line, stationResponses);
+        return LineResponse.of(line);
     }
 
     @Transactional
@@ -77,15 +71,5 @@ public class LineService {
         if (request.getUpStationId().equals(request.getDownStationId())) {
             throw new SubwayException(DUPLICATED_UP_STATION_AND_DOWN_STATION);
         }
-    }
-
-    private List<Station> extractStationsFrom(LineRequest request) {
-        Station upStation = stationRepository.findById(request.getUpStationId())
-                .orElseThrow(() -> new SubwayException(NOT_EXISTED_STATION));
-
-        Station downStation = stationRepository.findById(request.getDownStationId())
-                .orElseThrow(() -> new SubwayException(NOT_EXISTED_STATION));
-
-        return List.of(upStation, downStation);
     }
 }

--- a/src/main/java/kuit/subway/line/service/LineService.java
+++ b/src/main/java/kuit/subway/line/service/LineService.java
@@ -84,6 +84,16 @@ public class LineService {
         return LineResponse.of(line);
     }
 
+    @Transactional
+    public LineResponse deleteSection(Long lineId) {
+        Line line = lineRepository.findById(lineId)
+                .orElseThrow(() -> new SubwayException(NOT_EXISTED_LINE));
+
+        line.removeSection();
+
+        return LineResponse.of(line);
+    }
+
     private void validateDuplicatedStations(LineRequest request) {
         if (request.getUpStationId().equals(request.getDownStationId())) {
             throw new SubwayException(DUPLICATED_UP_STATION_AND_DOWN_STATION);

--- a/src/main/java/kuit/subway/line/service/LineService.java
+++ b/src/main/java/kuit/subway/line/service/LineService.java
@@ -4,6 +4,7 @@ import kuit.subway.global.exception.SubwayException;
 import kuit.subway.line.domain.Line;
 import kuit.subway.line.domain.Section;
 import kuit.subway.line.dto.request.LineRequest;
+import kuit.subway.line.dto.request.SectionRequest;
 import kuit.subway.line.dto.response.LineCreateResponse;
 import kuit.subway.line.dto.response.LineResponse;
 import kuit.subway.line.repository.LineRepository;
@@ -65,6 +66,22 @@ public class LineService {
                 .orElseThrow(() -> new SubwayException(NOT_EXISTED_LINE));
 
         lineRepository.delete(line);
+    }
+
+    @Transactional
+    public LineResponse createSection(Long lineId, SectionRequest request) {
+        Line line = lineRepository.findById(lineId)
+                .orElseThrow(() -> new SubwayException(NOT_EXISTED_LINE));
+
+        Station upStation = stationRepository.findById(request.getUpStationId())
+                .orElseThrow(() -> new SubwayException(NOT_EXISTED_STATION));
+        Station downStation = stationRepository.findById(request.getDownStationId())
+                .orElseThrow(() -> new SubwayException(NOT_EXISTED_STATION));
+
+        Section section = Section.createSection(request.getDistance(), line, upStation, downStation);
+        line.addSection(section);
+
+        return LineResponse.of(line);
     }
 
     private void validateDuplicatedStations(LineRequest request) {

--- a/src/main/java/kuit/subway/station/domain/Station.java
+++ b/src/main/java/kuit/subway/station/domain/Station.java
@@ -24,6 +24,7 @@ public class Station {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "station_id")
     private Long id;
 
     @Column(length = 20, nullable = false)

--- a/src/main/java/kuit/subway/station/domain/Station.java
+++ b/src/main/java/kuit/subway/station/domain/Station.java
@@ -2,13 +2,9 @@ package kuit.subway.station.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import kuit.subway.line.domain.Line;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -29,12 +25,4 @@ public class Station {
 
     @Column(length = 20, nullable = false)
     private String name;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "line_id")
-    private Line line;
-
-    public void addLine(Line line) {
-        this.line = line;
-    }
 }

--- a/src/test/java/kuit/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/kuit/subway/acceptance/SectionAcceptanceTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import static kuit.subway.acceptance.fixtures.LineAcceptanceFixtures.노선_생성;
 import static kuit.subway.acceptance.fixtures.SectionAcceptanceFixtures.구간_생성;
+import static kuit.subway.acceptance.fixtures.SectionAcceptanceFixtures.구간_제거;
 import static kuit.subway.acceptance.fixtures.StationAcceptanceFixtures.지하철역_생성;
 import static kuit.subway.utils.fixtures.LineFixtures.노선_요청;
 import static kuit.subway.utils.fixtures.SectionFixtures.구간_생성_요청;
@@ -65,6 +66,34 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 
         //when
         ExtractableResponse<Response> response = 구간_생성(1L, 구간_생성_요청(10L, 1L, 2L));
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @DisplayName("노선에 등록된 하행 종점역을 제거한다.")
+    @Test
+    void deleteSection(){
+        //given
+        지하철역_생성(지하철역_생성_요청("건대입구역"));
+        구간_생성(1L, 구간_생성_요청(10L, 3L, 2L));
+
+        //when
+        ExtractableResponse<Response> response = 구간_제거(1L);
+        List<Object> stations = response.jsonPath().getList("stations.");
+
+        //then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(stations).hasSize(2)
+        );
+    }
+
+    @DisplayName("노선에 구간이 1개인 경우 구간을 삭제하면, 예외가 발생한다.")
+    @Test
+    void deleteSection_Throw_Exception_If_Section_Size_Equal_One(){
+        //when
+        ExtractableResponse<Response> response = 구간_제거(1L);
 
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());

--- a/src/test/java/kuit/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/kuit/subway/acceptance/SectionAcceptanceTest.java
@@ -1,0 +1,72 @@
+package kuit.subway.acceptance;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+import static kuit.subway.acceptance.fixtures.LineAcceptanceFixtures.노선_생성;
+import static kuit.subway.acceptance.fixtures.SectionAcceptanceFixtures.구간_생성;
+import static kuit.subway.acceptance.fixtures.StationAcceptanceFixtures.지하철역_생성;
+import static kuit.subway.utils.fixtures.LineFixtures.노선_요청;
+import static kuit.subway.utils.fixtures.SectionFixtures.구간_생성_요청;
+import static kuit.subway.utils.fixtures.StationFixtures.지하철역_생성_요청;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class SectionAcceptanceTest extends AcceptanceTest {
+
+    @BeforeEach
+    void init() {
+        지하철역_생성(지하철역_생성_요청("강남역"));
+        지하철역_생성(지하철역_생성_요청("성수역"));
+        노선_생성(노선_요청("경춘선", "grean", 10L, 2L, 1L));
+    }
+
+    @DisplayName("노선에 구간을 등록한다.")
+    @Test
+    void createSection(){
+        //given
+        지하철역_생성(지하철역_생성_요청("건대입구역"));
+
+        //when
+        ExtractableResponse<Response> response = 구간_생성(1L, 구간_생성_요청(10L, 3L, 2L));
+        List<Object> stations = response.jsonPath().getList("stations.");
+
+        //then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
+                () -> assertThat(stations).hasSize(3)
+        );
+    }
+
+    @DisplayName("새로운 구간의 상행역이 해당 노선에 등록되어있는 하행 종점역이 아닌 경우, 예외가 발생한다.")
+    @Test
+    void createSection_Throw_Exception_If_Mismatch_Up_Station_With_Existed_Down_Station(){
+        //given
+        지하철역_생성(지하철역_생성_요청("건대입구역"));
+
+        //when
+        ExtractableResponse<Response> response = 구간_생성(1L, 구간_생성_요청(10L, 3L, 1L));
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @DisplayName("새로운 구간의 하행역이 해당 노선에 등록되어 있는 경우, 예외를 발생한다.")
+    @Test
+    void createSection_Throw_Exception_If_Existed_Down_Station(){
+        //given
+        지하철역_생성(지하철역_생성_요청("건대입구역"));
+
+        //when
+        ExtractableResponse<Response> response = 구간_생성(1L, 구간_생성_요청(10L, 1L, 2L));
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+}

--- a/src/test/java/kuit/subway/acceptance/fixtures/SectionAcceptanceFixtures.java
+++ b/src/test/java/kuit/subway/acceptance/fixtures/SectionAcceptanceFixtures.java
@@ -4,6 +4,7 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import kuit.subway.line.dto.request.SectionRequest;
 
+import static kuit.subway.utils.RestAssuredUtils.delete;
 import static kuit.subway.utils.RestAssuredUtils.post;
 
 public class SectionAcceptanceFixtures {
@@ -12,5 +13,9 @@ public class SectionAcceptanceFixtures {
 
     public static ExtractableResponse<Response> 구간_생성(Long lineId, SectionRequest request) {
         return post(request, BASE_URL, lineId);
+    }
+
+    public static ExtractableResponse<Response> 구간_제거(Long lineId) {
+        return delete(BASE_URL, lineId);
     }
 }

--- a/src/test/java/kuit/subway/acceptance/fixtures/SectionAcceptanceFixtures.java
+++ b/src/test/java/kuit/subway/acceptance/fixtures/SectionAcceptanceFixtures.java
@@ -1,0 +1,16 @@
+package kuit.subway.acceptance.fixtures;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import kuit.subway.line.dto.request.SectionRequest;
+
+import static kuit.subway.utils.RestAssuredUtils.post;
+
+public class SectionAcceptanceFixtures {
+
+    private static final String BASE_URL = "/lines/{lineId}/sections";
+
+    public static ExtractableResponse<Response> 구간_생성(Long lineId, SectionRequest request) {
+        return post(request, BASE_URL, lineId);
+    }
+}

--- a/src/test/java/kuit/subway/utils/DatabaseCleanup.java
+++ b/src/test/java/kuit/subway/utils/DatabaseCleanup.java
@@ -35,7 +35,7 @@ public class DatabaseCleanup {
 
         for (String tableName : tableNames) {
             entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
-            entityManager.createNativeQuery("ALTER TABLE " + tableName + " ALTER COLUMN ID RESTART WITH 1").executeUpdate();
+            entityManager.createNativeQuery("ALTER TABLE " + tableName + " ALTER " + tableName + "_id" + " RESTART WITH 1").executeUpdate();
         }
 
         entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();

--- a/src/test/java/kuit/subway/utils/fixtures/SectionFixtures.java
+++ b/src/test/java/kuit/subway/utils/fixtures/SectionFixtures.java
@@ -1,0 +1,14 @@
+package kuit.subway.utils.fixtures;
+
+import kuit.subway.line.dto.request.SectionRequest;
+
+public class SectionFixtures {
+
+    public static SectionRequest 구간_생성_요청(Long distance, Long downStationId, Long upStationId) {
+        return SectionRequest.builder()
+                .distance(distance)
+                .downStationId(downStationId)
+                .upStationId(upStationId)
+                .build();
+    }
+}


### PR DESCRIPTION
갑자기 상승한 난이도에 정신을 못차리겠읍니다..
하루라도 빨리 정우님의 코드 리뷰를 받고 리팩토링해서 월욜까지 끝낼 수 있도록, 비록 지저분한 코드지만 PR올립니다..🥲

---

## ❓ 궁금한점
### 1. `Section` 관리
현재 `Line` 엔티티단에서 `Section` 등록 / 제거 및 `List<Station> stations`을 반환하는 모든 로직이 담겨있습니다. (+ 검증조건까지..) 
하지만, 이는 `Line`의 역할이 아니기에 이를 분리하면 좋겠는데 마땅한 방법이 안떠오릅니다.😥

또한, 현재 구간 등록 및 제거를 단순히 `List<Section>` 타입에서 `add` / `remove`를 통해 호출하고 있는데 이 부분도 정말 단순히 Step3 기능 구현만을 위한 코드이기에 너무 마음에 걸립니다.😰 

코드리뷰 이후, 인사이트를 얻어 최대한 깔끔하게 리팩토링하겠습니다 !

---

### 2. `Section`에서 `@ManyToOne` 2번 ?!
현재 `Section` 클래스에서, `downStation` 과 `upStation` 둘 모두와 연관관계를 매핑하기 위해, `Station` 엔티티와 `@ManyToOne` 관계가 두 번 발생합니다. 
```java
public class Section {

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    @Column(name = "section_id")
    private Long id;

    private Long distance;

    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "line_id")
    private Line line;

    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "up_station_id")
    private Station upStation;

    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "down_station_id")
    private Station downStation;
...
```
이렇듯 하나의 엔티티에 대해 두번 연관관계를 맺는 것은 처음이라 너무 낯섭니다.🥲
위와 같이 연관관계를 매핑한 경우, 아래와 같은 ERD 구조가 되는건가요?
![image](https://github.com/KUIT-1/atdd-subway/assets/97597051/3a20f5f3-5a26-403a-8552-9ce1d454ba9b)
