### PR TITLE
[2차과제 - Step1] 이상진

### DIFF
--- a/src/main/java/kuit/subway/global/exception/CustomExceptionStatus.java
+++ b/src/main/java/kuit/subway/global/exception/CustomExceptionStatus.java
@@ -23,9 +23,7 @@ public enum CustomExceptionStatus implements ExceptionStatus {
     DUPLICATED_UP_STATION_AND_DOWN_STATION(HttpStatus.BAD_REQUEST, "상행종점역과 하행종점역이 중복됩니다."),
 
     // section exception
-    INVALID_SECTION_NOT_EXISTED_DOWN_STATION(HttpStatus.BAD_REQUEST, "새로운 구간의 상행역은 해당 노선에 등록되어있는 하행 종점역이여야 합니다."),
-    INVALID_DOWN_STATION(HttpStatus.BAD_REQUEST, "새로운 구간의 하행역은 해당 노선에 등록되어있을 수 없습니다."),
-    DUPLICATED_SECTION(HttpStatus.BAD_REQUEST, "상행역과 하행역이 이미 노선에 등록되어 있습니다."),
+    EXISTED_STATION_IN_SECTIONS(HttpStatus.BAD_REQUEST, "상행역과 하행역이 이미 노선에 등록되어 있습니다."),
     EXCEED_DISTANCE(HttpStatus.BAD_REQUEST, "추가되는 역 사이의 거리는, 기존 역 사이 길이보다 크거나 같을 수 없습니다."),
     CANNOT_REMOVE_SECTION(HttpStatus.BAD_REQUEST, "상행 종점역과 하행 종점역만 있는 경우, 구간을 삭제할 수 없습니다.")
     ;

--- a/src/main/java/kuit/subway/global/exception/CustomExceptionStatus.java
+++ b/src/main/java/kuit/subway/global/exception/CustomExceptionStatus.java
@@ -24,7 +24,9 @@ public enum CustomExceptionStatus implements ExceptionStatus {
 
     // section exception
     INVALID_SECTION_NOT_EXISTED_DOWN_STATION(HttpStatus.BAD_REQUEST, "새로운 구간의 상행역은 해당 노선에 등록되어있는 하행 종점역이여야 합니다."),
-    INVALID_SECTION_CANNOT_CYCLE(HttpStatus.BAD_REQUEST, "새로운 구간의 하행역은 해당 노선에 등록되어있을 수 없습니다."),
+    INVALID_DOWN_STATION(HttpStatus.BAD_REQUEST, "새로운 구간의 하행역은 해당 노선에 등록되어있을 수 없습니다."),
+    DUPLICATED_SECTION(HttpStatus.BAD_REQUEST, "상행역과 하행역이 이미 노선에 등록되어 있습니다."),
+    EXCEED_DISTANCE(HttpStatus.BAD_REQUEST, "추가되는 역 사이의 거리는, 기존 역 사이 길이보다 크거나 같을 수 없습니다."),
     CANNOT_REMOVE_SECTION(HttpStatus.BAD_REQUEST, "상행 종점역과 하행 종점역만 있는 경우, 구간을 삭제할 수 없습니다.")
     ;
 

--- a/src/main/java/kuit/subway/line/controller/LineController.java
+++ b/src/main/java/kuit/subway/line/controller/LineController.java
@@ -2,6 +2,7 @@ package kuit.subway.line.controller;
 
 import jakarta.validation.Valid;
 import kuit.subway.line.dto.request.LineRequest;
+import kuit.subway.line.dto.request.LineUpdateRequest;
 import kuit.subway.line.dto.request.SectionRequest;
 import kuit.subway.line.dto.response.LineCreateResponse;
 import kuit.subway.line.dto.response.LineResponse;
@@ -42,7 +43,7 @@ public class LineController {
 
     @PostMapping("/{lineId}")
     public ResponseEntity<LineResponse> updateLine(@PathVariable Long lineId,
-                                                   @Valid @RequestBody LineRequest request) {
+                                                   @Valid @RequestBody LineUpdateRequest request) {
         LineResponse response = lineService.updateLine(lineId, request);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/kuit/subway/line/domain/Line.java
+++ b/src/main/java/kuit/subway/line/domain/Line.java
@@ -39,7 +39,8 @@ public class Line extends BaseTimeEntity {
     public Sections sections = new Sections();
 
     @Builder
-    public Line(String name, String color) {
+    public Line(Long id, String name, String color) {
+        this.id = id;
         this.name = name;
         this.color = color;
     }

--- a/src/main/java/kuit/subway/line/domain/Section.java
+++ b/src/main/java/kuit/subway/line/domain/Section.java
@@ -53,5 +53,9 @@ public class Section {
     public void changeUpStation(Station station) {
         this.upStation = station;
     }
+
+    public void changeDownStation(Station station) {
+        this.downStation = station;
+    }
 }
 

--- a/src/main/java/kuit/subway/line/domain/Section.java
+++ b/src/main/java/kuit/subway/line/domain/Section.java
@@ -49,5 +49,9 @@ public class Section {
                 .downStation(downStation)
                 .build();
     }
+
+    public void changeUpStation(Station station) {
+        this.upStation = station;
+    }
 }
 

--- a/src/main/java/kuit/subway/line/domain/Sections.java
+++ b/src/main/java/kuit/subway/line/domain/Sections.java
@@ -102,25 +102,23 @@ public class Sections {
         if (sections.isEmpty()) {
             return;
         }
-        validateLastDownStation(section);
         validateDuplicatedSection(section);
     }
 
-    // 새로운 구간의 하행역은 해당 노선에 등록되어있는 역일 수 없다.
-    private void validateLastDownStation(Section section) {
-        if (section.getDownStation().equals(findLastDownStation())) {
-            throw new SubwayException(INVALID_DOWN_STATION);
+    private void validateDuplicatedSection(Section section) {
+        if (isExistedUpStation(section) && isExistedDownStation(section)) {
+            throw new SubwayException(EXISTED_STATION_IN_SECTIONS);
         }
     }
 
-    // 상행역과 하행역이 이미 노선에 모두 등록되어 있다면 추가 불가
-    private void validateDuplicatedSection(Section section) {
-        sections.stream().filter(existedSection ->
-                existedSection.getUpStation().equals(section.getUpStation()) && existedSection.getDownStation().equals(section.getDownStation()))
-                .findFirst()
-                .ifPresent(existedSection -> {
-                    throw new SubwayException(DUPLICATED_SECTION);
-                });
+    private boolean isExistedUpStation(Section section) {
+        return sections.stream().anyMatch(existedSection ->
+                existedSection.getUpStation().equals(section.getUpStation()) || existedSection.getUpStation().equals(section.getDownStation()));
+    }
+
+    private boolean isExistedDownStation(Section section) {
+        return sections.stream().anyMatch(existedSection ->
+                existedSection.getDownStation().equals(section.getUpStation()) || existedSection.getDownStation().equals(section.getDownStation()));
     }
 
     private void validateSectionDistance(Section section, Section existedSection) {

--- a/src/main/java/kuit/subway/line/domain/Sections.java
+++ b/src/main/java/kuit/subway/line/domain/Sections.java
@@ -24,54 +24,61 @@ public class Sections {
         validateAvailableSection(section);
 
         if (!isFirstOrLastStation(section)) {
-            changeSection(section);
+            changeUpSection(section);
+            changeDownSection(section);
         }
         this.sections.add(section);
     }
 
     private boolean isFirstOrLastStation(Section section) {
         if (!sections.isEmpty()) {
-            return section.getUpStation().equals(findLastDownStation()) || section.getDownStation().equals(findFirstUpStation());
+            return section.getUpStation().equals(findLastSection().get().getDownStation())
+                    || section.getDownStation().equals(findFirstSection().get().getUpStation());
         }
         return true;
     }
 
-    private Station findFirstUpStation() {
-        Station station = sections.get(0).getUpStation();
-
-        for (Section section : sections) {
-            if (section.getDownStation().equals(station)) {
-                station = section.getUpStation();
-            }
-        }
-        return station;
+    private Optional<Section> findFirstSection() {
+        Optional<Section> firstSection = sections.stream().filter(section ->
+                        sections.stream().noneMatch(existedSection ->
+                                section.getUpStation().equals(existedSection.getDownStation())))
+                .findFirst();
+        return firstSection;
     }
 
-    private Station findLastDownStation() {
-        Station station = sections.get(0).getDownStation();
-
-        for (Section section : sections) {
-            if (section.getUpStation().equals(station)) {
-                station = section.getDownStation();
-            }
-        }
-        return station;
+    private Optional<Section> findLastSection() {
+        Optional<Section> lastSection = sections.stream().filter(section ->
+                        sections.stream().noneMatch(existedSection ->
+                                section.getDownStation().equals(existedSection.getUpStation())))
+                .findFirst();
+        return lastSection;
     }
 
     // 역 사이에 낀 경우
-    private void changeSection(Section section) {
+    private void changeUpSection(Section section) {
         sections.stream().filter(existedSection -> existedSection.getUpStation().equals(section.getUpStation()))
                 .findFirst()
                 .ifPresent(existedSection -> {
-                        validateSectionDistance(section, existedSection);
-                        existedSection.changeUpStation(section.getDownStation());
+                    validateSectionDistance(section, existedSection);
+                    existedSection.changeUpStation(section.getDownStation());
+                });
+    }
+
+    private void changeDownSection(Section section) {
+        sections.stream().filter(existedSection -> existedSection.getDownStation().equals(section.getDownStation()))
+                .findFirst()
+                .ifPresent(existedSection -> {
+                    validateSectionDistance(section, existedSection);
+                    existedSection.changeDownStation(section.getUpStation());
                 });
     }
 
     public List<Station> getStations() {
         List<Station> stations = new ArrayList<>();
-        Station upStation = findFirstUpStation();
+        Section firstSection = findFirstSection().get();
+        Station upStation = firstSection.getUpStation();
         Station downStation = null;
+
         stations.add(upStation);
 
         Optional<Section> section = findSection(upStation);

--- a/src/main/java/kuit/subway/line/domain/Sections.java
+++ b/src/main/java/kuit/subway/line/domain/Sections.java
@@ -113,12 +113,12 @@ public class Sections {
 
     private boolean isExistedUpStation(Section section) {
         return sections.stream().anyMatch(existedSection ->
-                existedSection.getUpStation().equals(section.getUpStation()) || existedSection.getUpStation().equals(section.getDownStation()));
+                section.getUpStation().equals(existedSection.getUpStation()) || section.getUpStation().equals(existedSection.getDownStation()));
     }
 
     private boolean isExistedDownStation(Section section) {
         return sections.stream().anyMatch(existedSection ->
-                existedSection.getDownStation().equals(section.getUpStation()) || existedSection.getDownStation().equals(section.getDownStation()));
+                section.getDownStation().equals(existedSection.getUpStation()) || section.getDownStation().equals(existedSection.getDownStation()));
     }
 
     private void validateSectionDistance(Section section, Section existedSection) {

--- a/src/main/java/kuit/subway/line/domain/Sections.java
+++ b/src/main/java/kuit/subway/line/domain/Sections.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static kuit.subway.global.exception.CustomExceptionStatus.*;
 
@@ -67,6 +68,28 @@ public class Sections {
                 });
     }
 
+    public List<Station> getStations() {
+        List<Station> stations = new ArrayList<>();
+        Station upStation = findFirstUpStation();
+        Station downStation = null;
+        stations.add(upStation);
+
+        Optional<Section> section = findSection(upStation);
+
+        while (section.isPresent()) {
+            downStation = section.get().getDownStation();
+            stations.add(downStation);
+            section = findSection(downStation);
+        }
+
+        return stations;
+    }
+
+    private Optional<Section> findSection(Station station) {
+        return sections.stream()
+                .filter(section -> section.getUpStation().equals(station))
+                .findFirst();
+    }
 
     public void removeSection() {
         if (sections.size() == 1) {

--- a/src/main/java/kuit/subway/line/dto/request/LineRequest.java
+++ b/src/main/java/kuit/subway/line/dto/request/LineRequest.java
@@ -23,8 +23,8 @@ public class LineRequest {
     @NotNull
     @Min(1)
     private Long distance;
-    private Long downStationId;
     private Long upStationId;
+    private Long downStationId;
 
     public Line toEntity() {
         return Line.builder()

--- a/src/main/java/kuit/subway/line/dto/request/LineUpdateRequest.java
+++ b/src/main/java/kuit/subway/line/dto/request/LineUpdateRequest.java
@@ -1,0 +1,20 @@
+package kuit.subway.line.dto.request;
+
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LineUpdateRequest {
+
+    @Size(min = 2, max = 10)
+    private String name;
+    @Size(min = 2, max = 10)
+    private String color;
+}

--- a/src/main/java/kuit/subway/line/dto/request/SectionRequest.java
+++ b/src/main/java/kuit/subway/line/dto/request/SectionRequest.java
@@ -17,6 +17,6 @@ public class SectionRequest {
     @NotNull
     @Min(1)
     private Long distance;
-    private Long downStationId;
     private Long upStationId;
+    private Long downStationId;
 }

--- a/src/main/java/kuit/subway/line/service/LineService.java
+++ b/src/main/java/kuit/subway/line/service/LineService.java
@@ -4,6 +4,7 @@ import kuit.subway.global.exception.SubwayException;
 import kuit.subway.line.domain.Line;
 import kuit.subway.line.domain.Section;
 import kuit.subway.line.dto.request.LineRequest;
+import kuit.subway.line.dto.request.LineUpdateRequest;
 import kuit.subway.line.dto.request.SectionRequest;
 import kuit.subway.line.dto.response.LineCreateResponse;
 import kuit.subway.line.dto.response.LineResponse;
@@ -50,7 +51,7 @@ public class LineService {
     }
 
     @Transactional
-    public LineResponse updateLine(Long lineId, LineRequest request) {
+    public LineResponse updateLine(Long lineId, LineUpdateRequest request) {
         Line line = lineRepository.findById(lineId)
                 .orElseThrow(() -> new SubwayException(NOT_EXISTED_LINE));
 

--- a/src/main/java/kuit/subway/line/service/LineService.java
+++ b/src/main/java/kuit/subway/line/service/LineService.java
@@ -29,8 +29,7 @@ public class LineService {
     @Transactional
     public LineCreateResponse createLine(LineRequest request) {
         validateDuplicatedStations(request);
-        Line line = request.toEntity();
-        lineRepository.save(line);
+        Line line = lineRepository.save(request.toEntity());
 
         Station upStation = stationRepository.findById(request.getUpStationId())
                 .orElseThrow(() -> new SubwayException(NOT_EXISTED_STATION));

--- a/src/test/java/kuit/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/kuit/subway/acceptance/LineAcceptanceTest.java
@@ -28,7 +28,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void createLine(){
         //when
-        ExtractableResponse<Response> response = 노선_생성(노선_요청("경춘선", "grean", 10L, 2L, 1L));
+        ExtractableResponse<Response> response = 노선_생성(노선_요청("경춘선", "grean", 10L, 1L, 2L));
 
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
@@ -39,7 +39,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
     void createLine_Throw_Exception_If_Invalid_Request(){
         //when
         ExtractableResponse<Response> response =
-                노선_생성(노선_요청("A".repeat(11),"G".repeat(11) , -1L, 2L, 1L));
+                노선_생성(노선_요청("A".repeat(11),"G".repeat(11) , -1L, 1L, 2L));
 
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());

--- a/src/test/java/kuit/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/kuit/subway/acceptance/SectionAcceptanceTest.java
@@ -25,7 +25,7 @@ public class SectionAcceptanceTest extends AcceptanceTest {
     void init() {
         지하철역_생성(지하철역_생성_요청("강남역"));
         지하철역_생성(지하철역_생성_요청("성수역"));
-        노선_생성(노선_요청("경춘선", "grean", 10L, 2L, 1L));
+        노선_생성(노선_요청("경춘선", "grean", 10L, 1L, 2L));
     }
 
     @DisplayName("노선에 구간을 등록한다.")
@@ -35,7 +35,7 @@ public class SectionAcceptanceTest extends AcceptanceTest {
         지하철역_생성(지하철역_생성_요청("건대입구역"));
 
         //when
-        ExtractableResponse<Response> response = 구간_생성(1L, 구간_생성_요청(10L, 3L, 2L));
+        ExtractableResponse<Response> response = 구간_생성(1L, 구간_생성_요청(10L, 2L, 3L));
         List<Object> stations = response.jsonPath().getList("stations.");
 
         //then
@@ -52,7 +52,7 @@ public class SectionAcceptanceTest extends AcceptanceTest {
         지하철역_생성(지하철역_생성_요청("건대입구역"));
 
         //when
-        ExtractableResponse<Response> response = 구간_생성(1L, 구간_생성_요청(11L, 3L, 1L));
+        ExtractableResponse<Response> response = 구간_생성(1L, 구간_생성_요청(11L, 1L, 3L));
 
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
@@ -73,7 +73,7 @@ public class SectionAcceptanceTest extends AcceptanceTest {
     void deleteSection(){
         //given
         지하철역_생성(지하철역_생성_요청("건대입구역"));
-        구간_생성(1L, 구간_생성_요청(10L, 3L, 2L));
+        구간_생성(1L, 구간_생성_요청(10L, 2L, 3L));
 
         //when
         ExtractableResponse<Response> response = 구간_제거(1L);

--- a/src/test/java/kuit/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/kuit/subway/acceptance/SectionAcceptanceTest.java
@@ -45,25 +45,22 @@ public class SectionAcceptanceTest extends AcceptanceTest {
         );
     }
 
-    @DisplayName("새로운 구간의 상행역이 해당 노선에 등록되어있는 하행 종점역이 아닌 경우, 예외가 발생한다.")
+    @DisplayName("추가되는 역 사이의 거리는 기존 역 사이 길이보다 크거나 같다면 예외가 발생한다.")
     @Test
     void createSection_Throw_Exception_If_Mismatch_Up_Station_With_Existed_Down_Station(){
         //given
         지하철역_생성(지하철역_생성_요청("건대입구역"));
 
         //when
-        ExtractableResponse<Response> response = 구간_생성(1L, 구간_생성_요청(10L, 3L, 1L));
+        ExtractableResponse<Response> response = 구간_생성(1L, 구간_생성_요청(11L, 3L, 1L));
 
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 
-    @DisplayName("새로운 구간의 하행역이 해당 노선에 등록되어 있는 경우, 예외를 발생한다.")
+    @DisplayName("상행역과 하행역이 이미 노선에 모두 등록되어 있다면 예외가 발생한다.")
     @Test
     void createSection_Throw_Exception_If_Existed_Down_Station(){
-        //given
-        지하철역_생성(지하철역_생성_요청("건대입구역"));
-
         //when
         ExtractableResponse<Response> response = 구간_생성(1L, 구간_생성_요청(10L, 1L, 2L));
 

--- a/src/test/java/kuit/subway/line/service/LineServiceTest.java
+++ b/src/test/java/kuit/subway/line/service/LineServiceTest.java
@@ -1,0 +1,62 @@
+package kuit.subway.line.service;
+
+import kuit.subway.line.domain.Line;
+import kuit.subway.line.dto.response.LineCreateResponse;
+import kuit.subway.line.repository.LineRepository;
+import kuit.subway.station.domain.Station;
+import kuit.subway.station.repository.StationRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static kuit.subway.utils.fixtures.LineFixtures.노선_요청;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class LineServiceTest {
+
+    @Mock
+    private StationRepository stationRepository;
+
+    @Mock
+    private LineRepository lineRepository;
+
+    @InjectMocks
+    private LineService lineService;
+
+    @DisplayName("라인을 생성한다.")
+    @Test
+    void createLine(){
+        //given
+        Station 강남역 = Station.builder().id(1L).name("강남역").build();
+        Station 성수역 = Station.builder().id(2L).name("성수역").build();
+        Line 경춘선 = Line.builder().id(1L).name("경춘선").color("green").build();
+
+        given(lineRepository.save(any(Line.class)))
+                .willReturn(경춘선);
+        given(stationRepository.findById(1L))
+                .willReturn(Optional.ofNullable(강남역));
+        given(stationRepository.findById(2L))
+                .willReturn(Optional.ofNullable(성수역));
+
+        //when
+        LineCreateResponse result =
+                lineService.createLine(노선_요청("경춘선", "green", 10L, 2L, 1L));
+
+        //then
+        verify(stationRepository, times(2)).findById(anyLong());
+        verify(lineRepository, times((1))).save(any(Line.class));
+        assertThat(result.getId()).isEqualTo(경춘선.getId());
+    }
+
+}

--- a/src/test/java/kuit/subway/line/service/LineServiceTest.java
+++ b/src/test/java/kuit/subway/line/service/LineServiceTest.java
@@ -2,6 +2,7 @@ package kuit.subway.line.service;
 
 import kuit.subway.line.domain.Line;
 import kuit.subway.line.dto.response.LineCreateResponse;
+import kuit.subway.line.dto.response.LineResponse;
 import kuit.subway.line.repository.LineRepository;
 import kuit.subway.station.domain.Station;
 import kuit.subway.station.repository.StationRepository;
@@ -16,6 +17,7 @@ import java.util.Optional;
 
 import static kuit.subway.utils.fixtures.LineFixtures.노선_요청;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
@@ -59,4 +61,24 @@ class LineServiceTest {
         assertThat(result.getId()).isEqualTo(경춘선.getId());
     }
 
+    @DisplayName("라인을 조회한다.")
+    @Test
+    void showLine(){
+        //given
+        Line line = Line.builder().id(1L).name("경춘선").color("green").build();
+
+        given(lineRepository.findById(1L))
+                .willReturn(Optional.ofNullable(line));
+
+        //when
+        LineResponse response = lineService.showLine(1L);
+
+        //then
+        verify(lineRepository, times(1)).findById(anyLong());
+        assertAll(
+                () -> assertThat(response.getId()).isEqualTo(1L),
+                () -> assertThat(response.getName()).isEqualTo(line.getName()),
+                () -> assertThat(response.getColor()).isEqualTo(line.getColor())
+        );
+    }
 }

--- a/src/test/java/kuit/subway/line/service/LineServiceTest.java
+++ b/src/test/java/kuit/subway/line/service/LineServiceTest.java
@@ -40,16 +40,16 @@ class LineServiceTest {
     @Test
     void createLine(){
         //given
-        Station 강남역 = Station.builder().id(1L).name("강남역").build();
-        Station 성수역 = Station.builder().id(2L).name("성수역").build();
-        Line 경춘선 = Line.builder().id(1L).name("경춘선").color("green").build();
+        Station gangnamStation = Station.builder().id(1L).name("강남역").build();
+        Station sungsuStation = Station.builder().id(2L).name("성수역").build();
+        Line line = Line.builder().id(1L).name("경춘선").color("green").build();
 
         given(lineRepository.save(any(Line.class)))
-                .willReturn(경춘선);
+                .willReturn(line);
         given(stationRepository.findById(1L))
-                .willReturn(Optional.ofNullable(강남역));
+                .willReturn(Optional.ofNullable(gangnamStation));
         given(stationRepository.findById(2L))
-                .willReturn(Optional.ofNullable(성수역));
+                .willReturn(Optional.ofNullable(sungsuStation));
 
         //when
         LineCreateResponse result =
@@ -58,7 +58,7 @@ class LineServiceTest {
         //then
         verify(stationRepository, times(2)).findById(anyLong());
         verify(lineRepository, times((1))).save(any(Line.class));
-        assertThat(result.getId()).isEqualTo(경춘선.getId());
+        assertThat(result.getId()).isEqualTo(line.getId());
     }
 
     @DisplayName("라인을 조회한다.")

--- a/src/test/java/kuit/subway/line/service/LineServiceTest.java
+++ b/src/test/java/kuit/subway/line/service/LineServiceTest.java
@@ -123,8 +123,8 @@ class LineServiceTest {
     @Nested
     class SectionTest {
 
-        Station newUpStation;
-        Station newDownStation;
+        private Station newUpStation;
+        private Station newDownStation;
 
         @BeforeEach
         void init() {

--- a/src/test/java/kuit/subway/line/service/LineServiceTest.java
+++ b/src/test/java/kuit/subway/line/service/LineServiceTest.java
@@ -69,7 +69,7 @@ class LineServiceTest {
 
         //when
         LineCreateResponse result =
-                lineService.createLine(노선_요청("경춘선", "green", 10L, 2L, 1L));
+                lineService.createLine(노선_요청("경춘선", "green", 10L, 1L, 2L));
 
         //then
         verify(stationRepository, times(2)).findById(anyLong());
@@ -148,7 +148,7 @@ class LineServiceTest {
                     .willReturn(Optional.ofNullable(newDownStation));
 
             //when
-            LineResponse response = lineService.createSection(1L, 구간_생성_요청(5L, 4L, 2L));
+            LineResponse response = lineService.createSection(1L, 구간_생성_요청(5L, 2L, 4L));
 
             //then
             verify(lineRepository, times(1)).findById(anyLong());
@@ -173,7 +173,7 @@ class LineServiceTest {
                     .willReturn(Optional.ofNullable(newDownStation));
 
             //when
-            LineResponse response = lineService.createSection(1L, 구간_생성_요청(5L, 1L, 4L));
+            LineResponse response = lineService.createSection(1L, 구간_생성_요청(5L, 4L, 1L));
 
             //then
             verify(lineRepository, times(1)).findById(anyLong());
@@ -198,7 +198,7 @@ class LineServiceTest {
                     .willReturn(Optional.ofNullable(newDownStation));
 
             //when
-            LineResponse response = lineService.createSection(1L, 구간_생성_요청(5L, 4L, 3L));
+            LineResponse response = lineService.createSection(1L, 구간_생성_요청(5L, 3L, 4L));
 
             //then
             verify(lineRepository, times(1)).findById(anyLong());
@@ -222,7 +222,7 @@ class LineServiceTest {
                     .willReturn(Optional.ofNullable(newDownStation));
 
             //when & then
-            assertThatThrownBy(() -> lineService.createSection(1L, 구간_생성_요청(5L, 2L, 3L)))
+            assertThatThrownBy(() -> lineService.createSection(1L, 구간_생성_요청(5L, 3L, 2L)))
                     .isInstanceOf(SubwayException.class)
                     .extracting("status")
                     .isEqualTo(EXISTED_STATION_IN_SECTIONS);
@@ -242,7 +242,7 @@ class LineServiceTest {
                     .willReturn(Optional.ofNullable(newDownStation));
 
             //when
-            assertThatThrownBy(() -> lineService.createSection(1L, 구간_생성_요청(10L, 4L, 2L)))
+            assertThatThrownBy(() -> lineService.createSection(1L, 구간_생성_요청(10L, 2L, 4L)))
                     .isInstanceOf(SubwayException.class)
                     .extracting("status")
                     .isEqualTo(EXCEED_DISTANCE);

--- a/src/test/java/kuit/subway/utils/fixtures/LineFixtures.java
+++ b/src/test/java/kuit/subway/utils/fixtures/LineFixtures.java
@@ -5,13 +5,13 @@ import kuit.subway.line.dto.request.LineUpdateRequest;
 
 public class LineFixtures {
 
-    public static LineRequest 노선_요청(String name, String color, Long distance, Long downStationId, Long upStationId) {
+    public static LineRequest 노선_요청(String name, String color, Long distance, Long upStationId, Long downStationId) {
         return LineRequest.builder()
                 .name(name)
                 .color(color)
                 .distance(distance)
-                .downStationId(downStationId)
                 .upStationId(upStationId)
+                .downStationId(downStationId)
                 .build();
     }
 

--- a/src/test/java/kuit/subway/utils/fixtures/LineFixtures.java
+++ b/src/test/java/kuit/subway/utils/fixtures/LineFixtures.java
@@ -1,6 +1,7 @@
 package kuit.subway.utils.fixtures;
 
 import kuit.subway.line.dto.request.LineRequest;
+import kuit.subway.line.dto.request.LineUpdateRequest;
 
 public class LineFixtures {
 
@@ -11,6 +12,13 @@ public class LineFixtures {
                 .distance(distance)
                 .downStationId(downStationId)
                 .upStationId(upStationId)
+                .build();
+    }
+
+    public static LineUpdateRequest 노선_변경_요청(String name, String color) {
+        return LineUpdateRequest.builder()
+                .name(name)
+                .color(color)
                 .build();
     }
 }

--- a/src/test/java/kuit/subway/utils/fixtures/SectionFixtures.java
+++ b/src/test/java/kuit/subway/utils/fixtures/SectionFixtures.java
@@ -4,11 +4,11 @@ import kuit.subway.line.dto.request.SectionRequest;
 
 public class SectionFixtures {
 
-    public static SectionRequest 구간_생성_요청(Long distance, Long downStationId, Long upStationId) {
+    public static SectionRequest 구간_생성_요청(Long distance, Long upStationId, Long downStationId) {
         return SectionRequest.builder()
                 .distance(distance)
-                .downStationId(downStationId)
                 .upStationId(upStationId)
+                .downStationId(downStationId)
                 .build();
     }
 }


### PR DESCRIPTION
Step1에서는 Mockist가 되어 테스트코드를 작성하였습니다.
Step2에서 Classicist가 되어 테스트코드를 작성하겠습니다 !

---

## 구간 추가 제약사항 변경
- [x]  기존에는 마지막 역을 기준으로만 구간 추가 → 위치와 상관 없이 추가 가능
  - [x]  새로운 역을 상행 종점으로 등록할 경우 맨 상위 구간으로 추가
  - [x]  새로운 역을 하행 종점으로 등록할 경우 맨 하위 구간으로 추가
     - 현재 요청받은 `section`의 `upStation`과 `downStation`에 대해  `findFirstUpStation`과, `findLastDownStation` 둘 중 하나와 동일한 경우는 `sections.add()`를 통해 단순히 리스트에 추가하는 작업을 진행
  - [x]  사이에 끼울 경우 각 기존 구간의 상행역 or 하행역을 신규 구간 정보로 잘 변경
     - 기존의 `sections`의 `upStation`을 탐색하며, 요청받은 `upStation`과 같은 경우,
        - 거리 예외처리를 진행하고,
        - 기존 `section`의 `upStation`을 요청받은 `downStation`으로 변경
   
         ![image](https://github.com/KUIT-1/atdd-subway/assets/97597051/b9334d97-52e6-46e7-820b-dd1fd0493313)
         (위의 사진과 같은 느낌으로 `sections`를 관리 !)
- [x]  **노선 조회 시 상행 종점을 기준으로 역들이 잘 정렬되어 반환되어야 함**
   ```java
    public List<Station> getStations() {
        List<Station> stations = new ArrayList<>();
        Station upStation = findFirstUpStation();
        Station downStation = null;
        stations.add(upStation);

        Optional<Section> section = findSection(upStation);

        while (section.isPresent()) {
            downStation = section.get().getDownStation();
            stations.add(downStation);
            section = findSection(downStation);
        }

        return stations;
    }
   ```
   - `findFirstUpStation()`을 `stations`에 추가하고,
   - 현재 `upStation`에 해당하는 `Section`을 `Optional`로 받아온 후,
   - 만약 `Optional` 값이 존재한다면, 현재 섹션의 `downStation`을 계속해서 `stations`에 추가하여 정렬된 노선 리스트를 구현

## 구간 추가 예외
- [x]  상행역과 하행역 둘 중 하나도 포함되어있지 않으면 추가 불가
   - 컨트롤러단에서 해결 `(findById().orElseThrow())`
- [x]  상행역과 하행역이 이미 노선에 모두 등록되어 있다면 추가 불가
   - `validateDuplicatedSection` 에서 검증
   ```java
    private void validateDuplicatedSection(Section section) {
        if (isExistedUpStation(section) && isExistedDownStation(section)) {
            throw new SubwayException(EXISTED_STATION_IN_SECTIONS);
        }
    }

    private boolean isExistedUpStation(Section section) {
        return sections.stream().anyMatch(existedSection ->
                section.getUpStation().equals(existedSection.getUpStation()) || section.getUpStation().equals(existedSection.getDownStation()));
    }

    private boolean isExistedDownStation(Section section) {
        return sections.stream().anyMatch(existedSection ->
                section.getDownStation().equals(existedSection.getUpStation()) || section.getDownStation().equals(existedSection.getDownStation()));
    }
   ```
   - 기존에 존재하는 `sections`를 탐색하며, 추가하고자 하는 `section`의 `upStation`과 동일한 `station`을 포함하고,
   - 기존에 존재하는 `sections`를 탐색하며, 추가하고자 하는 `section`의 `downStation`과 동일한 `station`을 포함하면 예외 발생
   
- [x]  역 사이에 새로운 역을 등록할 경우 기존 역 사이 길이보다 크거나 같으면 추가 불가
   - `validateSectionDistance` 에서 검증

---

## 리팩토링
### 1. DownStation에 상행역 추가가 안되던 점 해결
`UpStation`에 하행역을 추가하는 로직과 동일하게 `changeDownSection()` 메서드를 통해 이를 구현하였습니다.

---

### 2. `findFirstUpStation` / `findLastDownStation` -> `findFirstSection` / `findLastSection`
1번 문제를 해결하고, A-E-B-D 인 상태에서, C-B를 추가하려 했더니, 제대로 추가되지 않는 문제점이 발생하였습니다.
왜 문제가 발생했는지 로그를 열심히 찍어보니 아래와 같이 findFirstUpStation과 findLastStation에서 기대하던 A-D가 아닌 A-B가 출력됨을 확인할 수 있었습니다.

<img width="707" alt="Pasted Graphic 2" src="https://github.com/KUIT-1/atdd-subway/assets/97597051/1c0cc5a8-a22e-497b-bd1d-74f5a582a60e">

왜 이러한 문제가 발생하였는지 코드를 차근차근 다시 분석해보니, 기존에는 아래의 사진과 같이 Sections에 대해 **순차적**으로 탐색하며 시작과 끝 station을 구했었습니다.

<img width="477" alt="Pasted Graphic 4" src="https://github.com/KUIT-1/atdd-subway/assets/97597051/ce9adb71-8766-48d8-a018-93c333e73244">

여기서 문제가 됐던 부분은 **순차적**으로 탐색했다는 것이였습니다. 
만약 C-B를 추가하는 경우, 아래의 사진과 같이 DB가 구성되있을텐데요.

![image](https://github.com/KUIT-1/atdd-subway/assets/97597051/855e51c7-2e14-4990-86b1-7b4c475db181)

이때, 순차적으로 탐색하다보니, 4 -> 5 -> 2로 `lastDownStation`이 갱신되어 D(3)가 아닌, B(2)가 저장되는게 그 문제였습니다.

이를 해결하고자, 아래와 같이 리팩토링을 진행하였습니다.

<img width="779" alt="image" src="https://github.com/KUIT-1/atdd-subway/assets/97597051/fc4acd60-f393-421c-a419-f9d86fb551c8">

FirstSection의 경우, sections을 두번 반복하면서 처음 section의 upStation이 유일하면 이를 반환하도록, LastSection의 경우도 마찬가지로 downStation이 유일하다면 해당 section을 반환하도록 변경하여 이를 해결했습니다.

---

### 3. JPA equals (미완)
현재까지는 문제 없이 잘 동작하는데 알려주신 링크 및 다양한 글들을 참고해보며 왜 제대로 동작하는지 확인을 하는 중에 있습니다만.. 아직까지는 명확한 이유를 알기 어렵습니다.🥲
하지만 덕분에 기존엔 그저 지나쳤던 내용을 새로이 알게되어 감사한 마음입니다.😊
왜 제 코드에서는 정상 작동하는지 조금 더 시간을 갖고 디버깅해보고, 결과가 있으면 바로 공유하겠습니다 !