### PR TITLE
[2차 과제 - Step2] 이상진

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/kuit/subway/global/exception/CustomExceptionStatus.java
+++ b/src/main/java/kuit/subway/global/exception/CustomExceptionStatus.java
@@ -25,7 +25,8 @@ public enum CustomExceptionStatus implements ExceptionStatus {
     // section exception
     EXISTED_STATION_IN_SECTIONS(HttpStatus.BAD_REQUEST, "상행역과 하행역이 이미 노선에 등록되어 있습니다."),
     EXCEED_DISTANCE(HttpStatus.BAD_REQUEST, "추가되는 역 사이의 거리는, 기존 역 사이 길이보다 크거나 같을 수 없습니다."),
-    CANNOT_REMOVE_SECTION(HttpStatus.BAD_REQUEST, "상행 종점역과 하행 종점역만 있는 경우, 구간을 삭제할 수 없습니다.")
+    CANNOT_REMOVE_SECTION(HttpStatus.BAD_REQUEST, "상행 종점역과 하행 종점역만 있는 경우, 구간을 삭제할 수 없습니다."),
+    NOT_EXISTED_STATION_IN_SECTION(HttpStatus.NOT_FOUND, "노선에 등록되어 있지 않은 역입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kuit/subway/global/exception/CustomExceptionStatus.java
+++ b/src/main/java/kuit/subway/global/exception/CustomExceptionStatus.java
@@ -25,7 +25,7 @@ public enum CustomExceptionStatus implements ExceptionStatus {
     // section exception
     EXISTED_STATION_IN_SECTIONS(HttpStatus.BAD_REQUEST, "상행역과 하행역이 이미 노선에 등록되어 있습니다."),
     EXCEED_DISTANCE(HttpStatus.BAD_REQUEST, "추가되는 역 사이의 거리는, 기존 역 사이 길이보다 크거나 같을 수 없습니다."),
-    CANNOT_REMOVE_SECTION(HttpStatus.BAD_REQUEST, "상행 종점역과 하행 종점역만 있는 경우, 구간을 삭제할 수 없습니다."),
+    UNDER_MINIMUM_SECTION_SIZE(HttpStatus.BAD_REQUEST, "상행 종점역과 하행 종점역만 있는 경우, 구간을 삭제할 수 없습니다."),
     NOT_EXISTED_STATION_IN_SECTION(HttpStatus.NOT_FOUND, "노선에 등록되어 있지 않은 역입니다."),
     ;
 

--- a/src/main/java/kuit/subway/line/controller/LineController.java
+++ b/src/main/java/kuit/subway/line/controller/LineController.java
@@ -62,9 +62,10 @@ public class LineController {
                 .body(response);
     }
 
-    @DeleteMapping("/{lineId}/sections")
-    public ResponseEntity<LineResponse> deleteSection(@PathVariable Long lineId) {
-        LineResponse response = lineService.deleteSection(lineId);
+    @DeleteMapping("/{lineId}/sections/{stationId}")
+    public ResponseEntity<LineResponse> deleteSection(@PathVariable Long lineId,
+                                                      @PathVariable Long stationId) {
+        LineResponse response = lineService.deleteSection(lineId, stationId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/kuit/subway/line/domain/Line.java
+++ b/src/main/java/kuit/subway/line/domain/Line.java
@@ -54,8 +54,8 @@ public class Line extends BaseTimeEntity {
         sections.addSection(section);
     }
 
-    public void removeSection() {
-        sections.removeSection();
+    public void removeSection(Station station) {
+        sections.removeSection(station);
     }
 
     public List<Station> getStations() {

--- a/src/main/java/kuit/subway/line/domain/Section.java
+++ b/src/main/java/kuit/subway/line/domain/Section.java
@@ -57,5 +57,9 @@ public class Section {
     public void changeDownStation(Station station) {
         this.downStation = station;
     }
+
+    public void changeDistance(Long distance) {
+        this.distance = distance;
+    }
 }
 

--- a/src/main/java/kuit/subway/line/domain/Sections.java
+++ b/src/main/java/kuit/subway/line/domain/Sections.java
@@ -92,6 +92,36 @@ public class Sections {
         return stations;
     }
 
+    public void removeSection(Station station) {
+        validateRemovableStation();
+
+        Optional<Section> upSectionOptional = findUpSection(station);
+        Optional<Section> downSectionOptional = findDownSection(station);
+
+        if (upSectionOptional.isPresent() && downSectionOptional.isPresent()) {
+            Section upSection = upSectionOptional.get();
+            Section downSection = downSectionOptional.get();
+            Long distance = upSection.getDistance() + downSection.getDistance();
+
+            upSection.changeDistance(distance);
+            upSection.changeDownStation(downSection.getDownStation());
+            sections.remove(downSection);
+            return;
+        }
+
+        // 상행종점 제거
+        if (upSectionOptional.isPresent()) {
+            Section section = upSectionOptional.get();
+            sections.remove(section);
+            return;
+        }
+
+        // 하행종점 제거
+        Section section = downSectionOptional.get();
+        sections.remove(section);
+    }
+
+
     private Optional<Section> findUpSection(Station station) {
         return sections.stream()
                 .filter(section -> section.getDownStation().equals(station))
@@ -130,6 +160,12 @@ public class Sections {
     private void validateSectionDistance(Section section, Section existedSection) {
         if (section.getDistance() >= existedSection.getDistance()) {
             throw new SubwayException(EXCEED_DISTANCE);
+        }
+    }
+
+    private void validateRemovableStation() {
+        if (sections.size() == 1) {
+            throw new SubwayException(CANNOT_REMOVE_SECTION);
         }
     }
 }

--- a/src/main/java/kuit/subway/line/domain/Sections.java
+++ b/src/main/java/kuit/subway/line/domain/Sections.java
@@ -165,7 +165,7 @@ public class Sections {
 
     private void validateRemovableStation(Optional<Section> upSectionOptional, Optional<Section> downSectionOptional) {
         if (sections.size() == 1) {
-            throw new SubwayException(CANNOT_REMOVE_SECTION);
+            throw new SubwayException(UNDER_MINIMUM_SECTION_SIZE);
         }
 
         if (upSectionOptional.isEmpty() && downSectionOptional.isEmpty()) {

--- a/src/main/java/kuit/subway/line/domain/Sections.java
+++ b/src/main/java/kuit/subway/line/domain/Sections.java
@@ -81,28 +81,27 @@ public class Sections {
 
         stations.add(upStation);
 
-        Optional<Section> section = findSection(upStation);
+        Optional<Section> section = findDownSection(upStation);
 
         while (section.isPresent()) {
             downStation = section.get().getDownStation();
             stations.add(downStation);
-            section = findSection(downStation);
+            section = findDownSection(downStation);
         }
 
         return stations;
     }
 
-    private Optional<Section> findSection(Station station) {
+    private Optional<Section> findUpSection(Station station) {
         return sections.stream()
-                .filter(section -> section.getUpStation().equals(station))
+                .filter(section -> section.getDownStation().equals(station))
                 .findFirst();
     }
 
-    public void removeSection() {
-        if (sections.size() == 1) {
-            throw new SubwayException(CANNOT_REMOVE_SECTION);
-        }
-        sections.remove(sections.size() - 1);
+    private Optional<Section> findDownSection(Station station) {
+        return sections.stream()
+                .filter(section -> section.getUpStation().equals(station))
+                .findFirst();
     }
 
     private void validateAvailableSection(Section section) {

--- a/src/main/java/kuit/subway/line/domain/Sections.java
+++ b/src/main/java/kuit/subway/line/domain/Sections.java
@@ -93,10 +93,10 @@ public class Sections {
     }
 
     public void removeSection(Station station) {
-        validateRemovableStation();
-
         Optional<Section> upSectionOptional = findUpSection(station);
         Optional<Section> downSectionOptional = findDownSection(station);
+
+        validateRemovableStation(upSectionOptional, downSectionOptional);
 
         if (upSectionOptional.isPresent() && downSectionOptional.isPresent()) {
             Section upSection = upSectionOptional.get();
@@ -163,9 +163,13 @@ public class Sections {
         }
     }
 
-    private void validateRemovableStation() {
+    private void validateRemovableStation(Optional<Section> upSectionOptional, Optional<Section> downSectionOptional) {
         if (sections.size() == 1) {
             throw new SubwayException(CANNOT_REMOVE_SECTION);
+        }
+
+        if (upSectionOptional.isEmpty() && downSectionOptional.isEmpty()) {
+            throw new SubwayException(NOT_EXISTED_STATION_IN_SECTION);
         }
     }
 }

--- a/src/main/java/kuit/subway/line/service/LineService.java
+++ b/src/main/java/kuit/subway/line/service/LineService.java
@@ -85,11 +85,12 @@ public class LineService {
     }
 
     @Transactional
-    public LineResponse deleteSection(Long lineId) {
+    public LineResponse deleteSection(Long lineId, Long stationId) {
         Line line = lineRepository.findById(lineId)
                 .orElseThrow(() -> new SubwayException(NOT_EXISTED_LINE));
-
-        line.removeSection();
+        Station station = stationRepository.findById(stationId)
+                .orElseThrow(() -> new SubwayException(NOT_EXISTED_STATION));
+        line.removeSection(station);
 
         return LineResponse.of(line);
     }

--- a/src/test/java/kuit/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/kuit/subway/acceptance/SectionAcceptanceTest.java
@@ -76,13 +76,15 @@ public class SectionAcceptanceTest extends AcceptanceTest {
         구간_생성(1L, 구간_생성_요청(10L, 2L, 3L));
 
         //when
-        ExtractableResponse<Response> response = 구간_제거(1L);
+        ExtractableResponse<Response> response = 구간_제거(1L, 3L);
         List<Object> stations = response.jsonPath().getList("stations.");
 
         //then
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(stations).hasSize(2)
+                        .extracting("name")
+                        .containsExactly("강남역", "성수역")
         );
     }
 
@@ -90,7 +92,7 @@ public class SectionAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteSection_Throw_Exception_If_Section_Size_Equal_One(){
         //when
-        ExtractableResponse<Response> response = 구간_제거(1L);
+        ExtractableResponse<Response> response = 구간_제거(1L, 2L);
 
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());

--- a/src/test/java/kuit/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/kuit/subway/acceptance/SectionAcceptanceTest.java
@@ -68,7 +68,7 @@ public class SectionAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 
-    @DisplayName("노선에 등록된 하행 종점역을 제거한다.")
+    @DisplayName("노선에 등록된 역 중 하나를 제거한다.")
     @Test
     void deleteSection(){
         //given

--- a/src/test/java/kuit/subway/acceptance/fixtures/SectionAcceptanceFixtures.java
+++ b/src/test/java/kuit/subway/acceptance/fixtures/SectionAcceptanceFixtures.java
@@ -15,7 +15,7 @@ public class SectionAcceptanceFixtures {
         return post(request, BASE_URL, lineId);
     }
 
-    public static ExtractableResponse<Response> 구간_제거(Long lineId) {
-        return delete(BASE_URL, lineId);
+    public static ExtractableResponse<Response> 구간_제거(Long lineId, Long stationId) {
+        return delete(BASE_URL + "/{stationId}", lineId, stationId);
     }
 }

--- a/src/test/java/kuit/subway/line/service/LineServiceTest.java
+++ b/src/test/java/kuit/subway/line/service/LineServiceTest.java
@@ -247,5 +247,65 @@ class LineServiceTest {
                     .extracting("status")
                     .isEqualTo(EXCEED_DISTANCE);
         }
+
+        @DisplayName("구간 삭제중, 중간역이 제거될 경우 재배치한다.")
+        @Test
+        void removeSection(){
+            //given
+            given(lineRepository.findById(anyLong()))
+                    .willReturn(Optional.ofNullable(line));
+            given(stationRepository.findById(anyLong()))
+                    .willReturn(Optional.ofNullable(downStation));
+
+            //when
+            LineResponse response = lineService.deleteSection(1L, 2L);
+
+            //then
+            verify(lineRepository, times(1)).findById(anyLong());
+            verify(stationRepository, times(1)).findById(anyLong());
+            assertThat(response.getStations()).hasSize(2)
+                            .extracting("name")
+                            .containsExactly("강남역","잠실역");
+        }
+
+        @DisplayName("구간 삭제중, 상행 종점이 제거될 경우 다음 역이 종점이 된다.")
+        @Test
+        void removeSection_If_Remove_First_Up_Station(){
+            //given
+            given(lineRepository.findById(anyLong()))
+                    .willReturn(Optional.ofNullable(line));
+            given(stationRepository.findById(anyLong()))
+                    .willReturn(Optional.ofNullable(upStation));
+
+            //when
+            LineResponse response = lineService.deleteSection(1L, 1L);
+
+            //then
+            verify(lineRepository, times(1)).findById(anyLong());
+            verify(stationRepository, times(1)).findById(anyLong());
+            assertThat(response.getStations()).hasSize(2)
+                    .extracting("name")
+                    .containsExactly("성수역","잠실역");
+        }
+
+        @DisplayName("구간 삭제중, 하행 종점이 제거될 경우 그 앞의 역이 종점이 된다.")
+        @Test
+        void removeSection_If_Remove_Last_Down_Station(){
+            //given
+            given(lineRepository.findById(anyLong()))
+                    .willReturn(Optional.ofNullable(line));
+            given(stationRepository.findById(anyLong()))
+                    .willReturn(Optional.ofNullable(newDownStation));
+
+            //when
+            LineResponse response = lineService.deleteSection(1L, 3L);
+
+            //then
+            verify(lineRepository, times(1)).findById(anyLong());
+            verify(stationRepository, times(1)).findById(anyLong());
+            assertThat(response.getStations()).hasSize(2)
+                    .extracting("name")
+                    .containsExactly("강남역","성수역");
+        }
     }
 }

--- a/src/test/java/kuit/subway/line/service/LineServiceTest.java
+++ b/src/test/java/kuit/subway/line/service/LineServiceTest.java
@@ -19,13 +19,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
-import static kuit.subway.global.exception.CustomExceptionStatus.EXCEED_DISTANCE;
-import static kuit.subway.global.exception.CustomExceptionStatus.EXISTED_STATION_IN_SECTIONS;
+import static kuit.subway.global.exception.CustomExceptionStatus.*;
 import static kuit.subway.utils.fixtures.LineFixtures.노선_변경_요청;
 import static kuit.subway.utils.fixtures.LineFixtures.노선_요청;
 import static kuit.subway.utils.fixtures.SectionFixtures.구간_생성_요청;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -306,6 +304,42 @@ class LineServiceTest {
             assertThat(response.getStations()).hasSize(2)
                     .extracting("name")
                     .containsExactly("강남역","성수역");
+        }
+
+        @DisplayName("노선에 등록되어 있지 않은 역은 제거가 불가능하다.")
+        @Test
+        void removeSection_Throw_Exception_If_Not_Existed_Station() {
+            newDownStation = Station.builder().id(4L).name("잠실새내역").build();
+
+            //given
+            given(lineRepository.findById(anyLong()))
+                    .willReturn(Optional.ofNullable(line));
+            given(stationRepository.findById(anyLong()))
+                    .willReturn(Optional.ofNullable(newDownStation));
+
+            //when & then
+            assertThatThrownBy(() -> lineService.deleteSection(1L, 4L))
+                    .isInstanceOf(SubwayException.class)
+                    .extracting("status")
+                    .isEqualTo(NOT_EXISTED_STATION_IN_SECTION);
+        }
+
+        @DisplayName("노선에 등록되어 있지 않은 역은 제거가 불가능하다.")
+        @Test
+        void removeSection_Throw_Exception_If_Only_One_Section() {
+            //given
+            given(lineRepository.findById(anyLong()))
+                    .willReturn(Optional.ofNullable(line));
+            given(stationRepository.findById(anyLong()))
+                    .willReturn(Optional.ofNullable(newDownStation));
+
+            lineService.deleteSection(1L, 3L);
+
+            //when & then
+            assertThatThrownBy(() -> lineService.deleteSection(1L, 2L))
+                    .isInstanceOf(SubwayException.class)
+                    .extracting("status")
+                    .isEqualTo(UNDER_MINIMUM_SECTION_SIZE);
         }
     }
 }


### PR DESCRIPTION
- [x]  구간 삭제 제약 사항 변경
    ```java
    private Optional<Section> findUpSection(Station station) {
        return sections.stream()
                .filter(section -> section.getDownStation().equals(station))
                .findFirst();
    }

    private Optional<Section> findDownSection(Station station) {
        return sections.stream()
                .filter(section -> section.getUpStation().equals(station))
                .findFirst();
    }
    ```
    * `findUpSection(Station station)` :  A-B-C 라인에서 station이 B 일때, B를 기준으로 위쪽 Section return (A-B)
    * `findDownSection(Station station)` : A-B-C 라인에서 station이 B 일때, B를 기준으로 아래쪽 Section return (B-C)
    * 위 두 메서드의 반환값인 `Optional<Section>`의 결과에 따라 아래와 같이 분기처리가 됩니다.
       * `upSection` 존재 x -> 상행 종점
       * `downSection` 존재 x -> 하행 종점
       * 둘다 존재 -> 사이에 낀 경우
       * 둘다 존재 X -> 해당 line에 존재하지 않는 station -> 예외처리


    - [x]  기존에는 마지막 역만 삭제 → 위치에 상관 없이 삭제 가능
    - [x]  종점이 제거될 경우 다음으로 오던 역이 종점이 되도록 구현
        * 종점이 제거되는 경우, 단순히 sections.remove()를 통해 해당 section을 제거합니다.
     
    - [x]  중간역이 제거될 경우 재배치해야한다.
        - A - B - C 구간에서 B 제거 → A - C 로 재배치
        - 거리는 두 구간의 거리의 합 (A-B 거리 + B-C 거리)
        
        ```java
        if (upSectionOptional.isPresent() && downSectionOptional.isPresent()) {
            Section upSection = upSectionOptional.get();
            Section downSection = downSectionOptional.get();
            Long distance = upSection.getDistance() + downSection.getDistance();

            upSection.changeDistance(distance);
            upSection.changeDownStation(downSection.getDownStation());
            sections.remove(downSection);
            return;
        }
        ```
        * 만약 중간에 낀 경우라면, 아래의 사진처럼 `upSection`에서 변경을 진행하고, `downSection`를 제거하였습니다.
        
          ![image](https://github.com/KUIT-1/atdd-subway/assets/97597051/df89aadb-e3c7-4185-9d97-b03415842352)

- [x]  구간 삭제 예외
    * `validateRemovableStation()` 에서 검증처리를 진행합니다.
    - [x]  노선에 등록되어 있지 않은 역은 제거 불가
       * 만약 `upSectionOptional`과 `downSectionOptional`에 값이 존재하지 않다면, 예외처리
    - [x]  구간이 하나인 노선에서 구간 제거 불가